### PR TITLE
Fix logging for MCP server

### DIFF
--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -4,12 +4,13 @@ import logging
 
 from fastmcp import FastMCP
 
+from ..services.logging_config import configure_logging
 from .service_manager import UnifiedServiceManager
 from .tools import collections
 from .tools import search
 
 # Initialize logging
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server

--- a/src/services/logging_config.py
+++ b/src/services/logging_config.py
@@ -4,6 +4,8 @@ import logging
 import sys
 from typing import Any
 
+from ..config import get_config
+
 
 # Custom formatter for structured logging
 class ServiceLayerFormatter(logging.Formatter):
@@ -23,7 +25,7 @@ class ServiceLayerFormatter(logging.Formatter):
 
 
 def configure_logging(
-    level: str = "INFO",
+    level: str | None = None,
     enable_color: bool = True,
     log_file: str | None = None,
 ) -> None:
@@ -34,6 +36,14 @@ def configure_logging(
         enable_color: Enable colored output for console
         log_file: Optional log file path
     """
+    config = get_config()
+
+    if level is None:
+        level = config.log_level.value
+
+    if log_file is None and hasattr(config, "log_file"):
+        log_file = config.log_file
+
     # Create root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(getattr(logging, level.upper()))

--- a/src/unified_mcp_server.py
+++ b/src/unified_mcp_server.py
@@ -41,6 +41,7 @@ try:
     from mcp.models.responses import SearchResult
     from mcp.service_manager import UnifiedServiceManager
     from security import SecurityValidator
+    from services.logging_config import configure_logging
 except ImportError:
     from .chunking import ChunkingConfig
     from .chunking import chunk_content
@@ -55,9 +56,10 @@ except ImportError:
     from .mcp.models.responses import SearchResult
     from .mcp.service_manager import UnifiedServiceManager
     from .security import SecurityValidator
+    from .services.logging_config import configure_logging
 
 # Initialize logging
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server

--- a/tests/test_unified_architecture.py
+++ b/tests/test_unified_architecture.py
@@ -14,6 +14,14 @@ from src.services.project_storage import ProjectStorage
 from src.services.qdrant_service import QdrantService
 
 
+class APIConfig(UnifiedConfig):
+    """Minimal adapter for legacy APIConfig tests."""
+
+    @classmethod
+    def from_unified_config(cls):
+        return get_config()
+
+
 class TestUnifiedConfig:
     """Test the unified configuration system."""
 


### PR DESCRIPTION
## Summary
- use centralized logging configuration for UnifiedMCP server
- update legacy MCP server module
- pull logging level from UnifiedConfig
- fix minor Ruff issues in tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `uv run pytest --cov=src` *(fails: No route to host)*