### PR TITLE
feat(services): Standardize ProjectStorage default path via UnifiedConfig

### DIFF
--- a/src/mcp/service_manager.py
+++ b/src/mcp/service_manager.py
@@ -43,8 +43,8 @@ class UnifiedServiceManager(BaseService):
             # CacheManager uses specific parameters from unified config
             self.cache_manager = CacheManager(
                 redis_url=self.config.cache.redis_url,
-                enable_local_cache=self.config.cache.local_enabled,
-                enable_redis_cache=self.config.cache.redis_enabled,
+                enable_local_cache=self.config.cache.enable_local_cache,
+                enable_redis_cache=self.config.cache.enable_redis_cache,
                 local_max_size=self.config.cache.local_max_size,
                 local_max_memory_mb=self.config.cache.local_max_memory_mb,
                 redis_ttl_seconds={
@@ -54,8 +54,8 @@ class UnifiedServiceManager(BaseService):
                 },
             )
 
-            # Initialize project storage
-            self.project_storage = ProjectStorage()
+            # Initialize project storage with data_dir from config
+            self.project_storage = ProjectStorage(data_dir=self.config.data_dir)
 
             # Initialize each service
             await self.embedding_manager.initialize()

--- a/src/services/project_storage.py
+++ b/src/services/project_storage.py
@@ -30,17 +30,27 @@ class ProjectStorageError(BaseError):
 class ProjectStorage:
     """Manages persistent storage of project configurations."""
 
-    def __init__(self, storage_path: str | Path | None = None):
+    def __init__(
+        self,
+        storage_path: str | Path | None = None,
+        data_dir: str | Path | None = None,
+    ):
         """Initialize project storage.
 
         Args:
-            storage_path: Path to storage file. Defaults to data/projects.json
+            storage_path: Path to storage file. If not provided, defaults to data_dir/projects.json
+            data_dir: Base data directory. If not provided, defaults to project root/data
         """
         if storage_path is None:
-            # Create data directory in project root
-            data_dir = Path(__file__).parent.parent.parent / "data"
-            data_dir.mkdir(exist_ok=True)
-            storage_path = data_dir / "projects.json"
+            # Use provided data_dir or fall back to old default
+            if data_dir is not None:
+                base_dir = Path(data_dir)
+            else:
+                # Fallback to maintain backward compatibility
+                base_dir = Path(__file__).parent.parent.parent / "data"
+
+            base_dir.mkdir(exist_ok=True)
+            storage_path = base_dir / "projects.json"
 
         self.storage_path = Path(storage_path)
         self._lock = asyncio.Lock()

--- a/src/services/project_storage.py
+++ b/src/services/project_storage.py
@@ -32,23 +32,17 @@ class ProjectStorage:
 
     def __init__(
         self,
+        data_dir: str | Path,
         storage_path: str | Path | None = None,
-        data_dir: str | Path | None = None,
     ):
         """Initialize project storage.
 
         Args:
-            storage_path: Path to storage file. If not provided, defaults to data_dir/projects.json
-            data_dir: Base data directory. If not provided, defaults to project root/data
+            data_dir: Base data directory from UnifiedConfig
+            storage_path: Optional custom path to storage file. If not provided, defaults to data_dir/projects.json
         """
         if storage_path is None:
-            # Use provided data_dir or fall back to old default
-            if data_dir is not None:
-                base_dir = Path(data_dir)
-            else:
-                # Fallback to maintain backward compatibility
-                base_dir = Path(__file__).parent.parent.parent / "data"
-
+            base_dir = Path(data_dir)
             base_dir.mkdir(exist_ok=True)
             storage_path = base_dir / "projects.json"
 

--- a/src/services/project_storage.py
+++ b/src/services/project_storage.py
@@ -38,12 +38,13 @@ class ProjectStorage:
         """Initialize project storage.
 
         Args:
-            data_dir: Base data directory from UnifiedConfig
-            storage_path: Optional custom path to storage file. If not provided, defaults to data_dir/projects.json
+            data_dir: Required base data directory from UnifiedConfig. Must be provided.
+            storage_path: Optional custom path to storage file. If not provided, defaults to data_dir/projects.json.
+                When both storage_path and data_dir are provided, storage_path takes precedence.
         """
         if storage_path is None:
             base_dir = Path(data_dir)
-            base_dir.mkdir(exist_ok=True)
+            base_dir.mkdir(parents=True, exist_ok=True)
             storage_path = base_dir / "projects.json"
 
         self.storage_path = Path(storage_path)


### PR DESCRIPTION
## Summary
- Refactored ProjectStorage to use configurable data directory from UnifiedConfig
- Ensures all data resides in a centralized, configurable location  
- **BREAKING CHANGE**: Removed backward compatibility - `data_dir` is now required

## Changes Made
1. **Modified ProjectStorage.__init__**: Made `data_dir` a required parameter, removed all fallback logic
2. **Simplified default path logic**: If `storage_path` is not provided, it defaults to `Path(data_dir) / "projects.json"`
3. **Updated UnifiedServiceManager**: Now passes `config.data_dir` when initializing ProjectStorage
4. **Fixed cache config attributes**: Corrected `local_enabled` and `redis_enabled` to `enable_local_cache` and `enable_redis_cache`
5. **Updated all tests**: Modified to pass the required `data_dir` parameter

## Testing
- All existing ProjectStorage tests pass ✅
- New test added for data_dir functionality ✅
- Linting and formatting completed ✅

## Breaking Changes
- `ProjectStorage` now requires `data_dir` parameter - no more optional fallbacks
- All code instantiating `ProjectStorage` must provide `data_dir`

## Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)