### PR TITLE
feat(issue-39): make rate limits configurable via UnifiedConfig

### DIFF
--- a/config/templates/development.json
+++ b/config/templates/development.json
@@ -33,7 +33,25 @@
   "performance": {
     "max_concurrent_requests": 5,
     "request_timeout": 60.0,
-    "max_memory_usage_mb": 500.0
+    "max_memory_usage_mb": 500.0,
+    "default_rate_limits": {
+      "openai": {
+        "max_calls": 100,
+        "time_window": 60
+      },
+      "firecrawl": {
+        "max_calls": 20,
+        "time_window": 60
+      },
+      "crawl4ai": {
+        "max_calls": 10,
+        "time_window": 1
+      },
+      "qdrant": {
+        "max_calls": 50,
+        "time_window": 1
+      }
+    }
   },
   "security": {
     "require_api_keys": false,

--- a/config/templates/local-only.json
+++ b/config/templates/local-only.json
@@ -39,7 +39,17 @@
   "performance": {
     "max_concurrent_requests": 10,
     "request_timeout": 30.0,
-    "max_memory_usage_mb": 1000.0
+    "max_memory_usage_mb": 1000.0,
+    "default_rate_limits": {
+      "crawl4ai": {
+        "max_calls": 10,
+        "time_window": 1
+      },
+      "qdrant": {
+        "max_calls": 50,
+        "time_window": 1
+      }
+    }
   },
   "security": {
     "require_api_keys": false,

--- a/config/templates/production.json
+++ b/config/templates/production.json
@@ -53,7 +53,25 @@
     "retry_base_delay": 1.0,
     "retry_max_delay": 60.0,
     "max_memory_usage_mb": 2000.0,
-    "gc_threshold": 0.8
+    "gc_threshold": 0.8,
+    "default_rate_limits": {
+      "openai": {
+        "max_calls": 500,
+        "time_window": 60
+      },
+      "firecrawl": {
+        "max_calls": 100,
+        "time_window": 60
+      },
+      "crawl4ai": {
+        "max_calls": 50,
+        "time_window": 1
+      },
+      "qdrant": {
+        "max_calls": 100,
+        "time_window": 1
+      }
+    }
   },
   "security": {
     "require_api_keys": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,8 @@ asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -380,7 +380,49 @@ class PerformanceConfig(BaseModel):
         default=0.8, gt=0, le=1, description="GC trigger threshold"
     )
 
+    # Rate limiting configuration
+    default_rate_limits: dict[str, dict[str, int]] = Field(
+        default_factory=lambda: {
+            "openai": {"max_calls": 500, "time_window": 60},  # 500/min
+            "firecrawl": {"max_calls": 100, "time_window": 60},  # 100/min
+            "crawl4ai": {"max_calls": 50, "time_window": 1},  # 50/sec
+            "qdrant": {"max_calls": 100, "time_window": 1},  # 100/sec
+        },
+        description="Default rate limits by provider (max_calls per time_window seconds)",
+    )
+
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("default_rate_limits")
+    @classmethod
+    def validate_rate_limits(
+        cls, v: dict[str, dict[str, int]]
+    ) -> dict[str, dict[str, int]]:
+        """Validate rate limit configuration structure."""
+        for provider, limits in v.items():
+            if not isinstance(limits, dict):
+                raise ValueError(
+                    f"Rate limits for provider '{provider}' must be a dictionary"
+                )
+
+            required_keys = {"max_calls", "time_window"}
+            if not required_keys.issubset(limits.keys()):
+                raise ValueError(
+                    f"Rate limits for provider '{provider}' must contain "
+                    f"keys: {required_keys}, got: {set(limits.keys())}"
+                )
+
+            if limits["max_calls"] <= 0:
+                raise ValueError(
+                    f"max_calls for provider '{provider}' must be positive"
+                )
+
+            if limits["time_window"] <= 0:
+                raise ValueError(
+                    f"time_window for provider '{provider}' must be positive"
+                )
+
+        return v
 
 
 class EmbeddingConfig(BaseModel):

--- a/tests/test_rate_limiting_config.py
+++ b/tests/test_rate_limiting_config.py
@@ -1,0 +1,210 @@
+"""Tests for rate limiting configuration integration."""
+
+import pytest
+from src.config.models import PerformanceConfig
+from src.config.models import UnifiedConfig
+from src.services.rate_limiter import RateLimitManager
+from src.services.rate_limiter import initialize_rate_limiter
+
+
+class TestRateLimitingConfiguration:
+    """Test rate limiting configuration and integration."""
+
+    def test_performance_config_default_rate_limits(self):
+        """Test that PerformanceConfig has correct default rate limits."""
+        config = PerformanceConfig()
+
+        # Check that default rate limits are set correctly
+        assert "openai" in config.default_rate_limits
+        assert "firecrawl" in config.default_rate_limits
+        assert "crawl4ai" in config.default_rate_limits
+        assert "qdrant" in config.default_rate_limits
+
+        # Check structure of each provider
+        for _provider, limits in config.default_rate_limits.items():
+            assert "max_calls" in limits
+            assert "time_window" in limits
+            assert limits["max_calls"] > 0
+            assert limits["time_window"] > 0
+
+    def test_performance_config_custom_rate_limits(self):
+        """Test custom rate limits validation."""
+        custom_limits = {
+            "custom_provider": {"max_calls": 50, "time_window": 30},
+            "another_provider": {"max_calls": 100, "time_window": 60},
+        }
+
+        config = PerformanceConfig(default_rate_limits=custom_limits)
+        assert config.default_rate_limits == custom_limits
+
+    def test_performance_config_validation_errors(self):
+        """Test that invalid rate limits raise validation errors."""
+
+        # Test missing required keys
+        with pytest.raises(ValueError, match="must contain keys"):
+            PerformanceConfig(
+                default_rate_limits={
+                    "invalid": {"max_calls": 10}  # Missing time_window
+                }
+            )
+
+        # Test negative max_calls
+        with pytest.raises(ValueError, match="max_calls.*must be positive"):
+            PerformanceConfig(
+                default_rate_limits={"invalid": {"max_calls": -1, "time_window": 60}}
+            )
+
+        # Test negative time_window
+        with pytest.raises(ValueError, match="time_window.*must be positive"):
+            PerformanceConfig(
+                default_rate_limits={"invalid": {"max_calls": 10, "time_window": -1}}
+            )
+
+    def test_rate_limit_manager_with_config(self):
+        """Test RateLimitManager initialization with UnifiedConfig."""
+        # Create config with custom rate limits
+        config = UnifiedConfig()
+        config.performance.default_rate_limits = {
+            "test_provider": {"max_calls": 123, "time_window": 456}
+        }
+
+        # Create manager with config
+        manager = RateLimitManager(config)
+
+        # Check that limits are correctly set
+        assert manager.default_limits == config.performance.default_rate_limits
+
+        # Test that limiter is created with correct settings
+        limiter = manager.get_limiter("test_provider")
+        assert limiter.max_calls == 123
+        assert limiter.time_window == 456
+
+    def test_rate_limit_manager_without_config(self):
+        """Test RateLimitManager fallback to defaults when no config provided."""
+        manager = RateLimitManager()
+
+        # Check that fallback defaults are used
+        expected_defaults = {
+            "openai": {"max_calls": 500, "time_window": 60},
+            "firecrawl": {"max_calls": 100, "time_window": 60},
+            "crawl4ai": {"max_calls": 50, "time_window": 1},
+            "qdrant": {"max_calls": 100, "time_window": 1},
+        }
+        assert manager.default_limits == expected_defaults
+
+    def test_initialize_rate_limiter_function(self):
+        """Test the initialize_rate_limiter function."""
+        # Create config with custom limits
+        config = UnifiedConfig()
+        config.performance.default_rate_limits = {
+            "global_test": {"max_calls": 999, "time_window": 111}
+        }
+
+        # Initialize global manager
+        initialize_rate_limiter(config)
+
+        # Import again to get the updated global instance
+        from src.services.rate_limiter import rate_limit_manager as updated_manager
+
+        # Check that global manager was updated
+        limiter = updated_manager.get_limiter("global_test")
+        assert limiter.max_calls == 999
+        assert limiter.time_window == 111
+
+    def test_unified_config_rate_limits_integration(self):
+        """Test that UnifiedConfig properly includes rate limiting configuration."""
+        config = UnifiedConfig()
+
+        # Check that performance config is included and has rate limits
+        assert hasattr(config.performance, "default_rate_limits")
+        assert isinstance(config.performance.default_rate_limits, dict)
+
+        # Check that rate limits can be overridden
+        custom_limits = {"custom": {"max_calls": 42, "time_window": 24}}
+        config_data = {"performance": {"default_rate_limits": custom_limits}}
+        custom_config = UnifiedConfig(**config_data)
+        assert custom_config.performance.default_rate_limits == custom_limits
+
+    @pytest.mark.parametrize(
+        "provider,expected_max_calls,expected_time_window",
+        [
+            ("openai", 500, 60),
+            ("firecrawl", 100, 60),
+            ("crawl4ai", 50, 1),
+            ("qdrant", 100, 1),
+        ],
+    )
+    def test_default_rate_limits_values(
+        self, provider, expected_max_calls, expected_time_window
+    ):
+        """Test that default rate limits have expected values for each provider."""
+        config = PerformanceConfig()
+
+        assert provider in config.default_rate_limits
+        limits = config.default_rate_limits[provider]
+        assert limits["max_calls"] == expected_max_calls
+        assert limits["time_window"] == expected_time_window
+
+    def test_rate_limit_manager_provider_specific_limits(self):
+        """Test that RateLimitManager properly applies provider-specific limits."""
+        # Create config with different limits for each provider
+        config = UnifiedConfig()
+        config.performance.default_rate_limits = {
+            "provider_a": {"max_calls": 10, "time_window": 1},
+            "provider_b": {"max_calls": 20, "time_window": 2},
+            "provider_c": {"max_calls": 30, "time_window": 3},
+        }
+
+        manager = RateLimitManager(config)
+
+        # Test each provider gets its specific limits
+        limiter_a = manager.get_limiter("provider_a")
+        assert limiter_a.max_calls == 10
+        assert limiter_a.time_window == 1
+
+        limiter_b = manager.get_limiter("provider_b")
+        assert limiter_b.max_calls == 20
+        assert limiter_b.time_window == 2
+
+        limiter_c = manager.get_limiter("provider_c")
+        assert limiter_c.max_calls == 30
+        assert limiter_c.time_window == 3
+
+    def test_rate_limit_manager_unknown_provider_fallback(self):
+        """Test that unknown providers fall back to default limits."""
+        config = UnifiedConfig()
+        manager = RateLimitManager(config)
+
+        # Request limiter for unknown provider
+        limiter = manager.get_limiter("unknown_provider")
+
+        # Should fall back to default 60/min
+        assert limiter.max_calls == 60
+        assert limiter.time_window == 60
+
+    def test_complex_rate_limits_configuration(self):
+        """Test complex rate limiting configuration scenarios."""
+        complex_limits = {
+            "high_frequency_api": {"max_calls": 1000, "time_window": 1},  # 1000/sec
+            "medium_frequency_api": {"max_calls": 100, "time_window": 60},  # 100/min
+            "low_frequency_api": {"max_calls": 10, "time_window": 3600},  # 10/hour
+            "burst_api": {"max_calls": 5, "time_window": 1},  # 5/sec
+        }
+
+        config = PerformanceConfig(default_rate_limits=complex_limits)
+        assert config.default_rate_limits == complex_limits
+
+        # Test with RateLimitManager
+        unified_config = UnifiedConfig()
+        unified_config.performance.default_rate_limits = complex_limits
+
+        manager = RateLimitManager(unified_config)
+
+        # Verify each API gets correct limits
+        high_freq_limiter = manager.get_limiter("high_frequency_api")
+        assert high_freq_limiter.max_calls == 1000
+        assert high_freq_limiter.time_window == 1
+
+        low_freq_limiter = manager.get_limiter("low_frequency_api")
+        assert low_freq_limiter.max_calls == 10
+        assert low_freq_limiter.time_window == 3600

--- a/uv.lock
+++ b/uv.lock
@@ -62,6 +62,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.18" },
@@ -97,6 +102,9 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Summary

This PR implements configurable rate limiting by integrating the rate limiting system with the UnifiedConfig. The `default_limits` dictionary in `RateLimitManager` is no longer hardcoded and can now be customized through configuration.

### Key Changes

- **Added rate limiting configuration to PerformanceConfig**: New `default_rate_limits` field with comprehensive Pydantic validation
- **Updated RateLimitManager**: Modified constructor to accept UnifiedConfig and use configured rate limits
- **Added initialization function**: `initialize_rate_limiter()` allows updating the global rate limiter with configuration
- **Updated configuration templates**: Added rate limit examples in development, production, and local-only templates
- **Comprehensive test suite**: 14 test cases covering validation, integration, and edge cases
- **Backward compatibility**: Maintains fallback defaults when no configuration is provided

### Configuration Structure

```json
{
  "performance": {
    "default_rate_limits": {
      "openai": {"max_calls": 500, "time_window": 60},
      "firecrawl": {"max_calls": 100, "time_window": 60},
      "crawl4ai": {"max_calls": 50, "time_window": 1},
      "qdrant": {"max_calls": 100, "time_window": 1}
    }
  }
}
```

### Test Coverage

- ✅ Pydantic validation for rate limit configuration
- ✅ RateLimitManager integration with UnifiedConfig
- ✅ Global rate limiter initialization
- ✅ Configuration template examples
- ✅ Backward compatibility with defaults
- ✅ Provider-specific rate limit application
- ✅ Complex configuration scenarios

### Validation Features

- Validates required keys (`max_calls`, `time_window`)
- Ensures positive values for both fields
- Provides clear error messages for invalid configurations
- Supports any provider name for extensibility

## Test plan

- [x] All 14 tests pass
- [x] Linting and formatting checks pass
- [x] Backward compatibility maintained
- [x] Configuration templates updated
- [x] Pydantic validation working correctly

🤖 Generated with [Claude Code](https://claude.ai/code)