### PR TITLE
chore(chunking): remove legacy chunk_content wrapper function

### DIFF
--- a/src/chunking.py
+++ b/src/chunking.py
@@ -964,14 +964,3 @@ class EnhancedChunker:
             formatted.append(chunk_dict)
 
         return formatted
-
-
-# Legacy compatibility function
-def chunk_content(content: str, metadata: dict, config: ChunkingConfig) -> list[dict]:
-    """Legacy wrapper for compatibility with existing code."""
-    chunker = EnhancedChunker(config)
-    return chunker.chunk_content(
-        content=content,
-        title=metadata.get("title", ""),
-        url=metadata.get("url", ""),
-    )

--- a/src/unified_mcp_server.py
+++ b/src/unified_mcp_server.py
@@ -29,7 +29,7 @@ from fastmcp import FastMCP
 # Handle both module and script imports
 try:
     from chunking import ChunkingConfig
-    from chunking import chunk_content
+    from chunking import EnhancedChunker
     from config.enums import ChunkingStrategy
     from config.enums import SearchStrategy
     from mcp.models.requests import AnalyticsRequest
@@ -44,7 +44,7 @@ try:
     from services.logging_config import configure_logging
 except ImportError:
     from .chunking import ChunkingConfig
-    from .chunking import chunk_content
+    from .chunking import EnhancedChunker
     from .config.enums import ChunkingStrategy
     from .config.enums import SearchStrategy
     from .mcp.models.requests import AnalyticsRequest
@@ -385,10 +385,11 @@ async def add_document(request: DocumentRequest, ctx: Context) -> dict[str, Any]
         await ctx.debug(
             f"Chunking document {doc_id} with strategy {request.chunk_strategy}"
         )
-        chunks = chunk_content(
-            crawl_result.markdown,
-            crawl_result.metadata,
-            chunk_config,
+        chunker = EnhancedChunker(chunk_config)
+        chunks = chunker.chunk_content(
+            content=crawl_result.markdown,
+            title=crawl_result.metadata.get("title", ""),
+            url=request.url,
         )
         await ctx.debug(f"Created {len(chunks)} chunks for document {doc_id}")
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Removed the legacy `chunk_content()` wrapper function from `src/chunking.py`
- Updated `src/unified_mcp_server.py` to use `EnhancedChunker` directly instead of the legacy wrapper
- All chunking operations now consistently use the `EnhancedChunker` class instance

## Changes
1. **Removed legacy function**: The standalone `chunk_content()` function at the end of `chunking.py` has been removed
2. **Updated imports**: Changed imports in `unified_mcp_server.py` from `chunk_content` to `EnhancedChunker`
3. **Updated usage**: Modified the document processing in `unified_mcp_server.py` to instantiate `EnhancedChunker` and call its `chunk_content()` method directly

## Test Plan
- [x] Verified no other parts of the codebase use the legacy function via grep search
- [x] Confirmed imports work correctly (`from src.unified_mcp_server import *` succeeds)
- [x] Ran linting and formatting (all checks passed)
- [x] Chunking tests pass (test_chunking.py runs successfully)

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)