### PR TITLE
Add CLI coverage tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,29 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
-from dotenv import load_dotenv
-from qdrant_client.models import PointStruct
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for offline envs
+
+    def load_dotenv(*args, **kwargs):
+        """Fallback no-op load_dotenv implementation."""
+        return False
+
+
+try:
+    from qdrant_client.models import PointStruct  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - basic fallback
+    from dataclasses import dataclass
+
+    @dataclass
+    class PointStruct:  # type: ignore
+        """Simplified stand-in for qdrant_client.models.PointStruct."""
+
+        id: int
+        vector: list[float]
+        payload: dict
+
 
 # Load test environment variables at module import
 _test_env_path = Path(__file__).parent.parent / ".env.test"

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -347,11 +347,6 @@ class TestSetupLogging:
         assert logger.level == 40  # ERROR level
 
 
-# TODO: Fix CLI tests - they have issues with module loading and async wrapping
-# For now, commenting out to focus on core functionality tests
-@pytest.mark.skip(
-    reason="CLI tests need refactoring due to async/module loading issues"
-)
 class TestCLI:
     """Test the CLI commands."""
 


### PR DESCRIPTION
## Summary
- enable CLI tests in `test_vector_db.py`
- provide fallbacks in `conftest` when optional deps are missing

## Testing
- `ruff check --fix .`
- `ruff format .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

## Summary by Sourcery

Enable CLI coverage tests and ensure test suite robustness by re-enabling previously skipped CLI tests and adding fallbacks for optional dependencies in the test fixtures.

New Features:
- Enable CLI commands test suite in `test_vector_db.py` for CLI coverage

Enhancements:
- Provide a no-op fallback for `load_dotenv` when `dotenv` is not installed
- Add a simplified `PointStruct` dataclass stub when `qdrant_client.models` is unavailable

Tests:
- Un-skip `TestCLI` class to restore CLI test execution