### PR TITLE
Add cache integration tests

### DIFF
--- a/tests/integration/test_crawl4ai_real_sites.py
+++ b/tests/integration/test_crawl4ai_real_sites.py
@@ -8,7 +8,6 @@ import asyncio
 import os
 import time
 from typing import ClassVar
-from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 import pytest
@@ -150,7 +149,7 @@ Complete beginner's guide to JavaScript.
             success = mock_data.get("success", True)
             # Simulate realistic timing
             await asyncio.sleep(0.1)
-            
+
             return {
                 "success": success,
                 "url": url,

--- a/tests/integration/test_dragonfly_cache_integration.py
+++ b/tests/integration/test_dragonfly_cache_integration.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from src.services.cache.dragonfly_cache import DragonflyCache
+from src.services.cache.embedding_cache import EmbeddingCache
+from src.services.cache.search_cache import SearchResultCache
+
+
+@pytest.mark.asyncio
+async def test_embedding_cache_warm_and_invalidate():
+    df_cache = DragonflyCache()
+    df_cache.exists = AsyncMock(side_effect=[False, True])
+    df_cache.set = AsyncMock(return_value=True)
+    df_cache.scan_keys = AsyncMock(
+        return_value=[
+            "emb:openai:model:hash1",
+            "emb:openai:model:hash2",
+        ]
+    )
+    df_cache.delete_many = AsyncMock(
+        return_value={
+            "emb:openai:model:hash1": True,
+            "emb:openai:model:hash2": True,
+        }
+    )
+
+    cache = EmbeddingCache(cache=df_cache)
+
+    missing = await cache.warm_cache(["text1", "text2"], "model")
+    assert missing == ["text1"]
+
+    success = await cache.set_embedding("text1", "model", [0.1, 0.2])
+    assert success is True
+
+    deleted = await cache.invalidate_model("model")
+    assert deleted == 2
+
+
+@pytest.mark.asyncio
+async def test_search_cache_operations():
+    df_cache = DragonflyCache()
+    df_cache.get = AsyncMock(return_value=None)
+    df_cache.set = AsyncMock(return_value=True)
+    df_cache.scan_keys = AsyncMock(return_value=["search:default:hash"])
+    df_cache.delete_many = AsyncMock(return_value={"search:default:hash": True})
+
+    cache = SearchResultCache(cache=df_cache)
+
+    assert await cache.get_search_results("query") is None
+
+    success = await cache.set_search_results("query", [{"id": 1}], ttl=60)
+    assert success is True
+
+    deleted = await cache.invalidate_by_collection("default")
+    assert deleted == 1

--- a/tests/unit/services/test_dragonfly_cache.py
+++ b/tests/unit/services/test_dragonfly_cache.py
@@ -83,7 +83,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.get.return_value = json.dumps("test_value").encode()
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.get("test_key")
             assert result == "test_value"
             mock_client.get.assert_called_once_with("test:test_key")
@@ -94,7 +94,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.get.return_value = None
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.get("missing_key")
             assert result is None
             mock_client.get.assert_called_once_with("test:missing_key")
@@ -105,7 +105,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.set.return_value = True
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.set("test_key", "test_value", ttl=300)
             assert result is True
             mock_client.set.assert_called_once()
@@ -116,7 +116,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.delete.return_value = 1
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.delete("test_key")
             assert result is True
             mock_client.delete.assert_called_once_with("test:test_key")
@@ -127,7 +127,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.exists.return_value = 1
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.exists("test_key")
             assert result is True
             mock_client.exists.assert_called_once_with("test:test_key")
@@ -138,7 +138,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.ttl.return_value = 300
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.ttl("test_key")
             assert result == 300
             mock_client.ttl.assert_called_once_with("test:test_key")
@@ -149,7 +149,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.dbsize.return_value = 100
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.size()
             assert result == 100
             mock_client.dbsize.assert_called_once()
@@ -160,7 +160,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.flushdb.return_value = True
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.clear()
             assert result is True
             mock_client.flushdb.assert_called_once()
@@ -175,7 +175,7 @@ class TestDragonflyCache:
             json.dumps("value3").encode(),
         ]
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             keys = ["key1", "key2", "key3"]
             result = await cache.mget(keys)
             expected = {"key1": "value1", "key2": None, "key3": "value3"}
@@ -193,7 +193,7 @@ class TestDragonflyCache:
         mock_client.pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
         mock_client.pipeline.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             # Test batch set
             data = {"key1": "value1", "key2": "value2", "key3": "value3"}
             result = await cache.set_many(data, ttl=300)
@@ -212,7 +212,7 @@ class TestDragonflyCache:
 
         mock_client.scan_iter.return_value = mock_scan_iter()
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.scan_keys("key*")
             assert "key1" in result
             assert "key2" in result
@@ -226,7 +226,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.get.side_effect = RedisError("Connection failed")
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.get("test_key")
             assert result is None  # Should return None on error
 
@@ -236,7 +236,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.memory_usage.return_value = 1024
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             result = await cache.get_memory_usage("test_key")
             assert result == 1024
 
@@ -266,7 +266,7 @@ class TestDragonflyCache:
         mock_client = AsyncMock()
         mock_client.get.return_value = json.dumps("test_value").encode()
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             # Execute multiple concurrent operations
             tasks = [cache.get(f"key_{i}") for i in range(10)]
             results = await asyncio.gather(*tasks)
@@ -284,7 +284,7 @@ class TestDragonflyCache:
         mock_client.get.return_value = None  # Cache miss
         mock_client.set.return_value = True
 
-        with patch.object(cache, "_get_client", return_value=mock_client):
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
             # Simulate cache-aside pattern
             cached_value = await cache.get("user:123")
             if cached_value is None:
@@ -293,4 +293,31 @@ class TestDragonflyCache:
                 await cache.set("user:123", fresh_value, ttl=3600)
                 cached_value = fresh_value
 
-            assert cached_value == {"id": 123, "name": "John"}
+        assert cached_value == {"id": 123, "name": "John"}
+
+    @pytest.mark.asyncio
+    async def test_connection_failure_handled_gracefully(self, cache):
+        """Ensure connection errors are handled without raising."""
+        from redis.exceptions import ConnectionError
+
+        with patch.object(
+            cache,
+            "client",
+            AsyncMock(side_effect=ConnectionError("unavailable")),
+        ):
+            result = await cache.get("fail_key")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_set_custom_ttl(self, cache):
+        """Verify TTL parameter is forwarded to the client."""
+        mock_client = AsyncMock()
+        mock_client.set.return_value = True
+
+        with patch.object(cache, "client", AsyncMock(return_value=mock_client)):
+            await cache.set("custom_ttl", "value", ttl=123, nx=True)
+
+            mock_client.set.assert_awaited_once()
+            args, kwargs = mock_client.set.call_args
+            assert kwargs.get("ex") == 123
+            assert kwargs.get("nx") is True


### PR DESCRIPTION
## Summary
- expand Dragonfly cache unit tests for TTL and connection errors
- add embedding and search cache integration tests
- check documented Dragonfly throughput improvement

## Testing
- `pip install -r requirements.txt`
- `ruff check . --fix`
- `ruff format .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

## Summary by Sourcery

Add comprehensive tests for Dragonfly cache functionality and performance and refactor existing unit tests to use the updated client interface

Enhancements:
- Refactor unit tests to mock the public `client` attribute instead of the internal `_get_client`
- Replace Redis comparison with a FakeCache for performance benchmarking

Tests:
- Expand dragonfly cache unit tests to cover TTL, size, clear, batch operations, error handling, memory usage, concurrent operations, connection failures, and custom TTL forwarding
- Add performance test to validate that DragonflyCache is at least 4.5x faster than a Redis baseline
- Introduce integration tests for embedding cache warm‐up/invalidation and search cache get/set/invalidate operations

Chores:
- Remove redundant Redis backend comparison and trim trailing whitespace in existing tests