### PR TITLE
fix: finalize lazy logging conversions

### DIFF
--- a/src/benchmarks/hybrid_search_benchmark.py
+++ b/src/benchmarks/hybrid_search_benchmark.py
@@ -231,7 +231,7 @@ class HybridSearchBenchmark:
 
         """
         start_time = time.time()
-        logger.info(f"Starting comprehensive benchmark: {self.benchmark_config.name}")
+        logger.info("Starting comprehensive benchmark: %s", self.benchmark_config.name)
 
         results = BenchmarkResults(
             benchmark_name=self.benchmark_config.name,
@@ -292,10 +292,8 @@ class HybridSearchBenchmark:
             # Calculate total duration
             results.duration_seconds = time.time() - start_time
 
-            logger.info(
-                f"Benchmark completed in {results.duration_seconds:.2f} seconds"
-            )
-            logger.info(f"Meets targets: {results.meets_targets}")
+            logger.info("Benchmark completed in %.2f seconds", results.duration_seconds)
+            logger.info("Meets targets: %s", results.meets_targets)
 
         except Exception as e:
             logger.exception("Benchmark failed: ")
@@ -318,7 +316,7 @@ class HybridSearchBenchmark:
         load_results = {}
 
         for concurrent_users in self.benchmark_config.concurrent_users:
-            logger.info(f"Running load test with {concurrent_users} concurrent users")
+            logger.info("Running load test with %s concurrent users", concurrent_users)
 
             load_config = LoadTestConfig(
                 concurrent_users=concurrent_users,
@@ -388,7 +386,9 @@ class HybridSearchBenchmark:
                 total_predictions += 1
 
             except (asyncio.CancelledError, TimeoutError, RuntimeError) as e:
-                logger.warning(f"Classification failed for query '{query_text}': {e}")
+                logger.warning(
+                    "Classification failed for query '%s': %s", query_text, e
+                )
                 total_predictions += 1
 
         return correct_predictions / max(total_predictions, 1)
@@ -429,7 +429,9 @@ class HybridSearchBenchmark:
                 total_selections += 1
 
             except (ValueError, TypeError, UnicodeDecodeError) as e:
-                logger.warning(f"Model selection failed for query '{query_text}': {e}")
+                logger.warning(
+                    "Model selection failed for query '%s': %s", query_text, e
+                )
                 total_selections += 1
 
         return appropriate_selections / max(total_selections, 1)
@@ -459,7 +461,9 @@ class HybridSearchBenchmark:
                 total_fusions += 1
 
             except (asyncio.CancelledError, TimeoutError, RuntimeError) as e:
-                logger.warning(f"Fusion tuning failed for query '{query.query}': {e}")
+                logger.warning(
+                    "Fusion tuning failed for query '%s': %s", query.query, e
+                )
                 total_fusions += 1
 
         return effective_fusions / max(total_fusions, 1)
@@ -593,6 +597,6 @@ class HybridSearchBenchmark:
         with html_file.open("w") as f:
             f.write(html_report)
 
-        logger.info(f"Results saved to {output_dir}")
-        logger.info(f"JSON: {json_file}")
-        logger.info(f"HTML: {html_file}")
+        logger.info("Results saved to %s", output_dir)
+        logger.info("JSON: %s", json_file)
+        logger.info("HTML: %s", html_file)

--- a/src/benchmarks/hybrid_search_benchmark.py
+++ b/src/benchmarks/hybrid_search_benchmark.py
@@ -428,7 +428,7 @@ class HybridSearchBenchmark:
                     appropriate_selections += 1
                 total_selections += 1
 
-            except (ValueError, TypeError, UnicodeDecodeError) as e:
+            except (ValueError, TypeError) as e:
                 logger.warning(
                     "Model selection failed for query '%s': %s", query_text, e
                 )

--- a/src/benchmarks/load_test_runner.py
+++ b/src/benchmarks/load_test_runner.py
@@ -135,9 +135,7 @@ class LoadTestUser:
         if start_delay > 0:
             await asyncio.sleep(start_delay)
 
-        logger.debug(
-            f"User {self.user_id} starting session"
-        )  # TODO: Convert f-string to logging format
+        logger.debug("User %s starting session", self.user_id)
 
         session_start = time.time()
         requests_per_user = self.config.total_requests // self.config.concurrent_users
@@ -174,16 +172,16 @@ class LoadTestUser:
                     self.failures += 1
                     self.errors.append("timeout")
                     logger.debug(
-                        f"User {self.user_id}: Request timeout"
-                    )  # TODO: Convert f-string to logging format
+                        "User %s: Request timeout", self.user_id
+                    )
 
                 except (httpx.HTTPError, httpx.TimeoutException, ConnectionError) as e:
                     self.failures += 1
                     error_type = type(e).__name__
                     self.errors.append(error_type)
                     logger.debug(
-                        f"User {self.user_id}: Request failed - {error_type}"
-                    )  # TODO: Convert f-string to logging format
+                        "User %s: Request failed - %s", self.user_id, error_type
+                    )
 
                     if not self.config.retry_on_failure:
                         continue
@@ -226,7 +224,7 @@ class LoadTestUser:
                 await asyncio.sleep(think_time)
 
             except (TimeoutError, OSError, PermissionError):
-                logger.exception(f"User {self.user_id} session error")
+                logger.exception("User %s session error", self.user_id)
                 self.failures += 1
                 break
 
@@ -272,8 +270,9 @@ class LoadTestRunner:
 
         """
         logger.info(
-            f"Starting load test: {load_config.concurrent_users} users, "
-            f"{load_config.total_requests} requests"
+            "Starting load test: %s users, %s requests",
+            load_config.concurrent_users,
+            load_config.total_requests,
         )
 
         # Initialize users
@@ -470,9 +469,7 @@ class LoadTestRunner:
         stress_results = {}
 
         for user_count in range(step_size, max_users + 1, step_size):
-            logger.info(
-                f"Stress test step: {user_count} users"
-            )  # TODO: Convert f-string to logging format
+            logger.info("Stress test step: %s users", user_count)
 
             load_config = LoadTestConfig(
                 concurrent_users=user_count,
@@ -492,12 +489,14 @@ class LoadTestRunner:
                 # Check if system is breaking down
                 if metrics.error_rate > 0.5 or metrics.p95_response_time_ms > 10000:
                     logger.warning(
-                        f"System degradation detected at {user_count} users"
-                    )  # TODO: Convert f-string to logging format
+                        "System degradation detected at %s users", user_count
+                    )
                     break
 
             except (OSError, PermissionError):
-                logger.exception(f"Stress test failed at {user_count} users")
+                logger.exception(
+                    "Stress test failed at %s users", user_count
+                )
                 break
 
         return stress_results
@@ -535,7 +534,9 @@ class LoadTestRunner:
         )
 
         logger.info(
-            f"Starting endurance test: {duration_hours} hours, {concurrent_users} users"
+            "Starting endurance test: %s hours, %s users",
+            duration_hours,
+            concurrent_users,
         )
 
         return await self.run_load_test(search_service, test_queries, load_config)

--- a/src/benchmarks/performance_profiler.py
+++ b/src/benchmarks/performance_profiler.py
@@ -180,8 +180,8 @@ class PerformanceProfiler:
 
             except (asyncio.CancelledError, TimeoutError, RuntimeError) as e:
                 logger.debug(
-                    f"Query execution failed during profiling: {e}"
-                )  # TODO: Convert f-string to logging format
+                    "Query execution failed during profiling: %s", e
+                )
 
     async def _monitor_resources(self) -> None:
         """Monitor system resources continuously."""
@@ -239,8 +239,8 @@ class PerformanceProfiler:
 
             except (ConnectionError, OSError, TimeoutError) as e:
                 logger.warning(
-                    f"Error collecting resource snapshot: {e}"
-                )  # TODO: Convert f-string to logging format
+                    "Error collecting resource snapshot: %s", e
+                )
 
             await asyncio.sleep(self.sampling_interval)
 

--- a/src/security/ml_security.py
+++ b/src/security/ml_security.py
@@ -284,8 +284,8 @@ class MLSecurityValidator:
             # Validate executable path for security
             if not trivy_path.startswith(("/usr/bin/", "/usr/local/bin/", "/opt/")):
                 logger.warning(
-                    f"trivy found in unexpected location: {trivy_path}"
-                )  # TODO: Convert f-string to logging format
+                    "trivy found in unexpected location: %s", trivy_path
+                )
 
             # Validate image name for security
             if not image_name or ".." in image_name or "/" not in image_name:
@@ -424,17 +424,11 @@ class MLSecurityValidator:
         """
         # Use existing logging infrastructure
         if severity == "critical":
-            logger.error(
-                f"Security event: {event_type}", extra=details
-            )  # TODO: Convert f-string to logging format
+            logger.error("Security event: %s", event_type, extra=details)
         elif severity == "error":
-            logger.warning(
-                f"Security event: {event_type}", extra=details
-            )  # TODO: Convert f-string to logging format
+            logger.warning("Security event: %s", event_type, extra=details)
         else:
-            logger.info(
-                f"Security event: {event_type}", extra=details
-            )  # TODO: Convert f-string to logging format
+            logger.info("Security event: %s", event_type, extra=details)
 
     def get_security_summary(self) -> dict[str, Any]:
         """Get summary of security checks performed.

--- a/src/services/deployment/blue_green.py
+++ b/src/services/deployment/blue_green.py
@@ -309,7 +309,7 @@ class BlueGreenDeployment:
 
         # Switch back to the other environment
         if success := await self.switch_environments(force=True):
-            logger.info(f"Rollback completed successfully: {success}")
+            logger.info("Rollback completed successfully: %s", success)
             return True
 
         logger.error("Rollback failed")
@@ -398,7 +398,7 @@ class BlueGreenDeployment:
 
         if success := await self.switch_environments():
             self._deployment_status = BlueGreenStatus.COMPLETED
-            logger.info(f"Blue-green deployment completed successfully: {success}")
+            logger.info("Blue-green deployment completed successfully: %s", success)
         else:
             self._deployment_status = BlueGreenStatus.FAILED
             logger.error("Failed to switch environments")

--- a/src/services/fastapi/middleware/compression.py
+++ b/src/services/fastapi/middleware/compression.py
@@ -124,7 +124,7 @@ class CompressionMiddleware(BaseHTTPMiddleware):
         try:
             body = self._get_response_body(response)
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to get response body: {e}")
+            logger.warning("Failed to get response body: %s", e)
             return response
 
         # Skip if body is too small
@@ -134,7 +134,7 @@ class CompressionMiddleware(BaseHTTPMiddleware):
         try:
             compressed_body = gzip.compress(body, compresslevel=self.compression_level)
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to compress response body: {e}")
+            logger.warning("Failed to compress response body: %s", e)
             return response
 
         try:
@@ -142,7 +142,7 @@ class CompressionMiddleware(BaseHTTPMiddleware):
                 response, body, compressed_body, "gzip"
             )
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to create compressed response: {e}")
+            logger.warning("Failed to create compressed response: %s", e)
             return response
 
     def _get_response_body(self, response: Response) -> bytes:
@@ -336,7 +336,7 @@ class BrotliCompressionMiddleware(BaseHTTPMiddleware):
         try:
             body = self._get_response_body(response)
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to get response body: {e}")
+            logger.warning("Failed to get response body: %s", e)
             return response
 
         # Skip if body is too small
@@ -346,7 +346,7 @@ class BrotliCompressionMiddleware(BaseHTTPMiddleware):
         try:
             compressed_body = self.brotli.compress(body, quality=self.quality)
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to compress response body with Brotli: {e}")
+            logger.warning("Failed to compress response body with Brotli: %s", e)
             return response
 
         try:
@@ -354,7 +354,7 @@ class BrotliCompressionMiddleware(BaseHTTPMiddleware):
                 response, body, compressed_body, "br"
             )
         except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to create Brotli compressed response: {e}")
+            logger.warning("Failed to create Brotli compressed response: %s", e)
             return response
 
     def _get_response_body(self, response: Response) -> bytes:

--- a/src/services/fastapi/middleware/performance.py
+++ b/src/services/fastapi/middleware/performance.py
@@ -570,7 +570,7 @@ async def _cleanup_services():
     """Clean up services and connections."""
     try:
         await _perform_service_cleanup()
-    except (ImportError, ModuleNotFoundError, AttributeError) as e:
+    except (ImportError, AttributeError) as e:
         logger.warning("Service cleanup failed: %s", e)
 
 

--- a/src/services/fastapi/middleware/performance.py
+++ b/src/services/fastapi/middleware/performance.py
@@ -267,7 +267,7 @@ class PerformanceMiddleware(BaseHTTPMiddleware):
         try:
             return self._get_process_memory()
         except (subprocess.SubprocessError, OSError, TimeoutError) as e:
-            logger.warning(f"Failed to get memory usage: {e}")
+            logger.warning("Failed to get memory usage: %s", e)
             return None
 
     def _get_process_memory(self) -> float | None:
@@ -503,7 +503,7 @@ async def optimized_lifespan(_app):
     try:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     except (ConnectionError, OSError, TimeoutError) as e:
-        logger.warning(f"Failed to install uvloop: {e}")
+        logger.warning("Failed to install uvloop: %s", e)
     else:
         logger.info("uvloop event loop policy installed for better performance")
 
@@ -550,7 +550,7 @@ async def _warm_embedding_service(config, client_manager) -> None:
         await embedding_manager.initialize()
         await embedding_manager.generate_embeddings(["warmup query"])
     except (asyncio.CancelledError, TimeoutError, RuntimeError) as e:
-        logger.warning(f"Failed to warm embedding service: {e}")
+        logger.warning("Failed to warm embedding service: %s", e)
     else:
         logger.info("Embedding service warmed up successfully")
 
@@ -561,7 +561,7 @@ async def _warm_vector_database(client_manager) -> None:
         qdrant_client = await client_manager.get_qdrant_client()
         await qdrant_client.get_collections()
     except (ValueError, ConnectionError, TimeoutError, RuntimeError) as e:
-        logger.warning(f"Failed to warm vector database: {e}")
+        logger.warning("Failed to warm vector database: %s", e)
     else:
         logger.info("Vector database connection warmed up successfully")
 
@@ -571,7 +571,7 @@ async def _cleanup_services():
     try:
         await _perform_service_cleanup()
     except (ImportError, ModuleNotFoundError, AttributeError) as e:
-        logger.warning(f"Service cleanup failed: {e}")
+        logger.warning("Service cleanup failed: %s", e)
 
 
 async def _perform_service_cleanup() -> None:

--- a/src/services/functional/crawling.py
+++ b/src/services/functional/crawling.py
@@ -78,7 +78,7 @@ async def crawl_url(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"URL crawling failed for {url}")
+        logger.exception("URL crawling failed for %s", url)
         raise HTTPException(status_code=500, detail=f"Crawling failed: {e!s}") from e
     else:
         return result

--- a/src/services/monitoring/performance_monitor.py
+++ b/src/services/monitoring/performance_monitor.py
@@ -159,7 +159,7 @@ class RealTimePerformanceMonitor:
             logger.warning("Low throughput detected: %.1f req/s", snapshot.request_rate)
 
         if snapshot.cache_hit_rate < 0.8:  # Cache hit rate below 80%
-            logger.warning("Low cache hit rate: %.1f%%", snapshot.cache_hit_rate * 100)
+            logger.warning(f"Low cache hit rate: {snapshot.cache_hit_rate:.1%}")
 
     async def _optimize_memory(self) -> None:
         """Trigger memory optimization when usage is high."""

--- a/src/services/monitoring/performance_monitor.py
+++ b/src/services/monitoring/performance_monitor.py
@@ -152,16 +152,14 @@ class RealTimePerformanceMonitor:
         # Log performance warnings
         if snapshot.p95_response_time > 100:  # P95 > 100ms
             logger.warning(
-                f"High P95 latency detected: {snapshot.p95_response_time:.1f}ms"
+                "High P95 latency detected: %.1fms", snapshot.p95_response_time
             )
 
         if snapshot.request_rate > 0 and snapshot.request_rate < 10:  # Low throughput
-            logger.warning(
-                f"Low throughput detected: {snapshot.request_rate:.1f} req/s"
-            )
+            logger.warning("Low throughput detected: %.1f req/s", snapshot.request_rate)
 
         if snapshot.cache_hit_rate < 0.8:  # Cache hit rate below 80%
-            logger.warning(f"Low cache hit rate: {snapshot.cache_hit_rate:.1%}")
+            logger.warning("Low cache hit rate: %.1f%%", snapshot.cache_hit_rate * 100)
 
     async def _optimize_memory(self) -> None:
         """Trigger memory optimization when usage is high."""

--- a/tests/load/locust_load_runner.py
+++ b/tests/load/locust_load_runner.py
@@ -697,7 +697,7 @@ def save_load_test_report(summary: dict[str, Any], environment: Environment):
             json.dump(full_report, f, indent=2)
         logger.info(
             "Load test report saved to %s", report_file
-        )  # TODO: Convert f-string to logging format
+        )
     except Exception:
         logger.exception("Failed to save load test report")
 

--- a/tests/load/run_load_tests.py
+++ b/tests/load/run_load_tests.py
@@ -84,7 +84,7 @@ class LoadTestRunner:
         """Run load test using Locust."""
         logger.info(
             "Starting Locust load test with config: %s", config
-        )  # TODO: Convert f-string to logging format
+        )
 
         # Create environment
         env = create_load_test_environment(
@@ -98,7 +98,7 @@ class LoadTestRunner:
                 env.shape_class = load_profile
                 logger.info(
                     "Applied load profile: %s", profile
-                )  # TODO: Convert f-string to logging format
+                )
 
         if headless:
             # Run headless test
@@ -133,16 +133,16 @@ class LoadTestRunner:
                 report_file = self._save_report(report)
                 logger.info(
                     "Test report saved to: %s", report_file
-                )  # TODO: Convert f-string to logging format
+                )
 
             return report
         # Run with web UI
         logger.info(
             "Starting Locust web UI on port %s", web_port
-        )  # TODO: Convert f-string to logging format
+        )
         logger.info(
             "Visit http://localhost:%s to control the test", web_port
-        )  # TODO: Convert f-string to logging format
+        )
 
         # Set up Locust arguments for web mode
         locust_args = [
@@ -223,7 +223,7 @@ class LoadTestRunner:
         """Run a custom load test scenario from JSON file."""
         logger.info(
             "Running custom scenario: %s", scenario_file
-        )  # TODO: Convert f-string to logging format
+        )
 
         try:
             with Path(scenario_file).open() as f:
@@ -272,14 +272,14 @@ class LoadTestRunner:
         """Benchmark specific endpoints."""
         logger.info(
             "Benchmarking endpoints: %s", endpoints
-        )  # TODO: Convert f-string to logging format
+        )
 
         results = {}
 
         for endpoint in endpoints:
             logger.info(
                 "Benchmarking endpoint: %s", endpoint
-            )  # TODO: Convert f-string to logging format
+            )
 
             # Create custom user class for this endpoint
             endpoint_config = config.copy()
@@ -296,7 +296,7 @@ class LoadTestRunner:
         report_file = self._save_report(comparative_report, "endpoint_benchmark")
         logger.info(
             "Endpoint benchmark report saved to: %s", report_file
-        )  # TODO: Convert f-string to logging format
+        )
 
         return comparative_report
 
@@ -325,7 +325,7 @@ class LoadTestRunner:
             report_file = self._save_report(regression_analysis, "regression_analysis")
             logger.info(
                 "Regression analysis saved to: %s", report_file
-            )  # TODO: Convert f-string to logging format
+            )
 
         except Exception:
             logger.exception("Error in test execution")

--- a/tests/load/scalability/test_scalability_load.py
+++ b/tests/load/scalability/test_scalability_load.py
@@ -646,7 +646,7 @@ class TestScalabilityLoad:
 
                 logger.info(
                     "Expanded %s pool: %s -> %s", pool_type, old_size, pool["size"]
-                )  # TODO: Convert f-string to logging format
+                )
 
             def get_database_stats(self) -> dict:
                 """Get database scaling statistics."""

--- a/tests/load/spike_testing/test_spike_load.py
+++ b/tests/load/spike_testing/test_spike_load.py
@@ -185,7 +185,7 @@ class TestSpikeLoad:
                 )
                 logger.info(
                     "Scaled up from %s to %s", old_capacity, self.current_capacity
-                )  # TODO: Convert f-string to logging format
+                )
 
             def scale_down(self):
                 """Scale down capacity."""

--- a/tests/load/stress_testing/conftest.py
+++ b/tests/load/stress_testing/conftest.py
@@ -185,7 +185,7 @@ class FailureInjector:
 
         logger.warning(
             "Injecting memory pressure: %sMB for %ss", pressure_mb, duration
-        )  # TODO: Convert f-string to logging format
+        )
 
         # Allocate memory to create pressure
         memory_hogs = []
@@ -228,7 +228,7 @@ class FailureInjector:
 
         logger.warning(
             "Injecting CPU saturation: %.1f%% load for %ss", cpu_load * 100, duration
-        )  # TODO: Convert f-string to logging format
+        )
 
         # CPU intensive work
         stop_cpu_work = threading.Event()
@@ -509,7 +509,7 @@ class StressTestOrchestrator:
             phase_results.append(phase_result)
             logger.info(
                 "Completed stress test phase %s", i + 1
-            )  # TODO: Convert f-string to logging format
+            )
 
         return phase_results
 

--- a/tests/load/stress_testing/test_breaking_points.py
+++ b/tests/load/stress_testing/test_breaking_points.py
@@ -315,7 +315,7 @@ class TestBreakingPoints:
                 if error_rate > 25 and avg_response_time > 5000:
                     logger.warning(
                         "Breaking point reached at step %s", i + 1
-                    )  # TODO: Convert f-string to logging format
+                    )
                     break
 
             except Exception:
@@ -358,7 +358,7 @@ class TestBreakingPoints:
         )
         logger.info(
             "Maximum stable load: %s users", breaking_point.max_stable_users
-        )  # TODO: Convert f-string to logging format
+        )
         logger.info("Graceful degradation")
 
     @pytest.mark.stress
@@ -541,7 +541,7 @@ class TestBreakingPoints:
 
         logger.info(
             "Maximum handled spike: %s users", max_handled_spike
-        )  # TODO: Convert f-string to logging format
+        )
         logger.info("Spike success rate")
 
     @pytest.mark.stress

--- a/tests/load/stress_testing/test_circuit_breakers.py
+++ b/tests/load/stress_testing/test_circuit_breakers.py
@@ -455,7 +455,7 @@ class TestCircuitBreakers:
         for phase in phases:
             logger.info(
                 "Running recovery phase: %s", phase["name"]
-            )  # TODO: Convert f-string to logging format
+            )
 
             # Set service health
             service.set_health(phase["service_healthy"])
@@ -568,10 +568,10 @@ class TestCircuitBreakers:
         logger.info("Circuit breaker recovery completed successfully")
         logger.info(
             "Total state changes: %s", _total_state_changes
-        )  # TODO: Convert f-string to logging format
+        )
         logger.info(
             "Final circuit breaker metrics: %s", circuit_breaker.metrics
-        )  # TODO: Convert f-string to logging format
+        )
 
 
 class TestRateLimiters:
@@ -628,7 +628,7 @@ class TestRateLimiters:
         for pattern in load_patterns:
             logger.info(
                 "Testing rate limiter with load pattern: %s", pattern["name"]
-            )  # TODO: Convert f-string to logging format
+            )
 
             # Reset rate limiter for clean test
             rate_limiter.request_times.clear()

--- a/tests/load/stress_testing/test_stress_load.py
+++ b/tests/load/stress_testing/test_stress_load.py
@@ -88,7 +88,7 @@ class TestStressLoad:
                     breaking_point = current_users
                     logger.warning(
                         "Breaking point detected at %s users", current_users
-                    )  # TODO: Convert f-string to logging format
+                    )
 
         # Run stress test
         load_test_runner.run_load_test(
@@ -212,7 +212,7 @@ class TestStressLoad:
                 # Check if failure is cascading
                 logger.warning(
                     "Service failure: %s", e
-                )  # TODO: Convert f-string to logging format
+                )
             else:
                 await services.call_service("embedding")
                 await services.call_service("vector_db")

--- a/tests/load/stress_testing/test_system_monitoring.py
+++ b/tests/load/stress_testing/test_system_monitoring.py
@@ -162,7 +162,7 @@ class SystemMonitor:
             except (ConnectionError, RuntimeError, OSError) as e:
                 logger.warning(
                     "Error during monitoring: %s", e
-                )  # TODO: Convert f-string to logging format
+                )
 
             time.sleep(self.collection_interval)
 
@@ -322,7 +322,7 @@ class SystemMonitor:
             self.performance_alerts.append(alert)
             logger.warning(
                 "Performance alert: %s", message
-            )  # TODO: Convert f-string to logging format
+            )
 
     def get_metrics_summary(self) -> dict[str, Any]:
         """Get summary of collected metrics."""
@@ -556,7 +556,7 @@ class TestSystemMonitoring:
                         # Handle stress operation errors
                         logger.warning(
                             "Stress operation failed: %s", e
-                        )  # TODO: Convert f-string to logging format
+                        )
                         raise
                     else:
                         return {
@@ -601,7 +601,7 @@ class TestSystemMonitoring:
             for pattern in stress_patterns:
                 logger.info(
                     "Running stress pattern: %s", pattern["name"]
-                )  # TODO: Convert f-string to logging format
+                )
 
                 # Configure stress test
                 config = LoadTestConfig(
@@ -640,7 +640,7 @@ class TestSystemMonitoring:
 
                 logger.info(
                     "Completed stress pattern: %s", pattern["name"]
-                )  # TODO: Convert f-string to logging format
+                )
 
                 # Brief pause between patterns
                 await asyncio.sleep(5)
@@ -694,7 +694,7 @@ class TestSystemMonitoring:
             )
             logger.info(
                 "  - Performance alerts: %s", final_metrics["_total_alerts"]
-            )  # TODO: Convert f-string to logging format
+            )
             logger.info(
                 "  - Peak CPU: %.2f%%", final_metrics["system_metrics"]["cpu"]["max"]
             )


### PR DESCRIPTION
## Summary
- convert the remaining hybrid benchmark logging statements to lazy logger arguments and avoid f-string interpolation in runtime paths
- switch blue/green deployment, middleware, crawling, and performance monitoring modules to parameterized logging calls for consistent lazy evaluation

## Testing
- uv run ruff format . *(fails: uv cannot fully parse pyproject.toml due to unsupported `extra-build-dependencies` field, but formatting still executed)*
- uv run ruff check . --fix *(fails: repository contains existing UP038 lint violations without safe auto-fixes)*
- uv run pylint --fail-under=9.5 src tests *(fails: pylint executable not available in environment)*
- uv run python -m pytest -q *(fails: pytest module not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4996479c0832b96fdbe6e2af2ccaf

## Summary by Sourcery

Convert all f-string logging statements to lazy parameterized logger calls throughout the codebase

Enhancements:
- Refactor benchmark modules (load test runner, hybrid search, performance profiler) to use parameterized logging instead of f-strings
- Update middleware (compression, performance) and core services (security events, crawling, blue/green deployment) to delegate message formatting to logger parameters
- Align performance monitoring and deployment modules to lazy logging for warnings, info, and exception messages
- Revise all load and stress test suites (e.g., circuit breakers, scalability, spike, monitoring) to adopt the new parameterized logging style