### PR TITLE
refactor: remove legacy compatibility shims

### DIFF
--- a/src/mcp_tools/tools/collection_management.py
+++ b/src/mcp_tools/tools/collection_management.py
@@ -110,17 +110,13 @@ def register_tools(mcp, client_manager: ClientManager):  # pylint: disable=too-m
             vector_service = await client_manager.get_vector_store_service()
             cache_manager = await get_cache_manager(client_manager)
 
-            delete_alias = getattr(vector_service, "delete_collection", None)
             drop_method = getattr(vector_service, "drop_collection", None)
-            if callable(delete_alias):
-                delete_callable = cast(Callable[[str], Awaitable[None]], delete_alias)
-                await delete_callable(collection_name)
-            elif callable(drop_method):
-                drop_callable = cast(Callable[[str], Awaitable[None]], drop_method)
-                await drop_callable(collection_name)
-            else:  # pragma: no cover - defensive compatibility guard
+            if not callable(drop_method):  # pragma: no cover - defensive guard
                 msg = "Vector service does not expose a collection deletion method"
                 raise AttributeError(msg)
+
+            drop_callable = cast(Callable[[str], Awaitable[None]], drop_method)
+            await drop_callable(collection_name)
             if ctx:
                 await ctx.debug(f"Collection {collection_name} deleted from Qdrant")
 

--- a/src/mcp_tools/tools/documents.py
+++ b/src/mcp_tools/tools/documents.py
@@ -13,7 +13,7 @@ from src.config import ChunkingConfig, ChunkingStrategy
 from src.infrastructure.client_manager import ClientManager
 from src.mcp_tools.models.requests import BatchRequest, DocumentRequest
 from src.mcp_tools.models.responses import AddDocumentResponse, DocumentBatchResponse
-from src.security import SecurityValidator
+from src.security import MLSecurityValidator
 from src.services.dependencies import (
     get_cache_manager,
     get_content_intelligence_service,
@@ -309,9 +309,8 @@ def register_tools(mcp, client_manager: ClientManager):
             vector_service = await _get_vector_service(client_manager)
             cache_manager = await get_cache_manager(client_manager)
 
-            request.url = SecurityValidator.from_unified_config().validate_url(
-                request.url
-            )
+            security_validator = MLSecurityValidator.from_unified_config()
+            request.url = security_validator.validate_url(request.url)
 
             cache_key = f"doc:{request.url}"
             cached_result = await cache_manager.get(cache_key)
@@ -393,7 +392,7 @@ def register_tools(mcp, client_manager: ClientManager):
             async with semaphore:
                 try:
                     # Validate URL first
-                    security_validator = SecurityValidator.from_unified_config()
+                    security_validator = MLSecurityValidator.from_unified_config()
                     validated_url = security_validator.validate_url(url)
 
                     doc_request = DocumentRequest(

--- a/src/mcp_tools/tools/payload_indexing.py
+++ b/src/mcp_tools/tools/payload_indexing.py
@@ -65,7 +65,6 @@ def _normalise_summary(
         "indexed_fields_count": len(indexed_fields),
         "indexed_fields": indexed_fields,
         "total_points": points,
-        "_total_points": points,  # Retain legacy key for compatibility
         "payload_schema": payload_schema,
     }
     if request_id is not None:
@@ -143,7 +142,6 @@ def register_tools(mcp, client_manager: ClientManager):
                 "indexes_after": after["indexed_fields_count"],
                 "indexed_fields": after["indexed_fields"],
                 "total_points": after.get("points_count", 0),
-                "_total_points": after.get("points_count", 0),
                 "request_id": request_id,
             },
         )
@@ -203,7 +201,6 @@ def register_tools(mcp, client_manager: ClientManager):
             "performance_estimate": performance_estimate,
             "results": results,
             "total_points": stats.get("points_count", 0),
-            "_total_points": stats.get("points_count", 0),
             "indexed_fields": summary["indexed_fields"],
         }
         if ctx:

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -16,15 +16,9 @@ from .ml_security import (
 )
 
 
-# Add aliases for test compatibility
-SecurityError = Exception  # Simple alias for backward compatibility
-SecurityValidator = MLSecurityValidator  # Alias for test compatibility
-
 __all__ = [
     "MLSecurityValidator",
     "MinimalMLSecurityConfig",
     "SecurityCheckResult",
-    "SecurityError",
-    "SecurityValidator",
     "SimpleRateLimiter",
 ]

--- a/src/services/vector_db/service.py
+++ b/src/services/vector_db/service.py
@@ -131,11 +131,6 @@ class VectorStoreService(BaseService):  # pylint: disable=too-many-public-method
         client = self._require_async_client()
         await client.delete_collection(name)
 
-    async def delete_collection(self, name: str) -> None:
-        """Backward-compatible alias for drop_collection."""
-
-        await self.drop_collection(name)
-
     async def list_collections(self) -> list[str]:
         """Return the identifiers for all collections."""
 
@@ -950,7 +945,7 @@ def _filter_from_mapping(filters: Mapping[str, Any] | None) -> models.Filter | N
                     range=models.Range(**value),
                 )
             )
-        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        elif isinstance(value, Sequence) and not isinstance(value, str | bytes):
             must_conditions.append(
                 models.FieldCondition(
                     key=key,

--- a/tests/unit/mcp_tools/tools/test_collection_management.py
+++ b/tests/unit/mcp_tools/tools/test_collection_management.py
@@ -34,7 +34,6 @@ class TestCollectionsTools:
 
         mock_vector.collection_stats.side_effect = mock_stats
         mock_vector.drop_collection = AsyncMock()
-        mock_vector.delete_collection = AsyncMock()
 
         # Mock cache manager
         mock_cache = AsyncMock()
@@ -140,36 +139,7 @@ class TestCollectionsTools:
         assert result.collection == "old_collection"
 
         mock_context.info.assert_called()
-        mock_vector.delete_collection.assert_awaited_once_with("old_collection")
-        mock_vector.drop_collection.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_delete_collection_falls_back_to_drop(
-        self, mock_client_manager, mock_context
-    ):
-        """Test fallback to drop_collection when delete alias missing."""
-
-        mock_vector = await mock_client_manager.get_vector_store_service()
-        mock_vector.delete_collection = None
-
-        mock_mcp = MagicMock()
-        registered_tools = {}
-
-        def capture_tool(func):
-            registered_tools[func.__name__] = func
-            return func
-
-        mock_mcp.tool.return_value = capture_tool
-        register_tools(mock_mcp, mock_client_manager)
-
-        delete_collection = registered_tools["delete_collection"]
-
-        result = await delete_collection(
-            collection_name="legacy_collection", ctx=mock_context
-        )
-
-        assert result.status == "deleted"
-        mock_vector.drop_collection.assert_awaited_once_with("legacy_collection")
+        mock_vector.drop_collection.assert_awaited_once_with("old_collection")
 
     @pytest.mark.asyncio
     async def test_delete_collection_missing_methods(
@@ -178,7 +148,6 @@ class TestCollectionsTools:
         """Ensure an explicit error surfaces when delete/drop are unavailable."""
 
         mock_vector = await mock_client_manager.get_vector_store_service()
-        mock_vector.delete_collection = None
         mock_vector.drop_collection = None
 
         mock_mcp = MagicMock()

--- a/tests/unit/mcp_tools/tools/test_documents_ingest.py
+++ b/tests/unit/mcp_tools/tools/test_documents_ingest.py
@@ -124,7 +124,7 @@ def documents_env(monkeypatch) -> SimpleNamespace:  # pylint: disable=too-many-l
 
     validator = DummyValidator()
     monkeypatch.setattr(
-        documents.SecurityValidator,
+        documents.MLSecurityValidator,
         "from_unified_config",
         classmethod(lambda cls: validator),
     )

--- a/tests/unit/mcp_tools/tools/test_payload_indexing.py
+++ b/tests/unit/mcp_tools/tools/test_payload_indexing.py
@@ -99,6 +99,8 @@ def mock_context():
 
 @pytest.mark.asyncio
 async def test_tool_registration(mock_client_manager):
+    """Verify the payload indexing tools register correctly."""
+
     mock_mcp = MagicMock()
     registered = {}
 
@@ -122,6 +124,8 @@ async def test_tool_registration(mock_client_manager):
 async def test_create_payload_indexes(
     mock_client_manager, mock_vector_service, mock_context
 ):
+    """Ensure create_payload_indexes provisions indexes and returns metadata."""
+
     mock_mcp = MagicMock()
     registered = {}
     mock_mcp.tool.return_value = lambda func: registered.setdefault(func.__name__, func)
@@ -143,12 +147,15 @@ async def test_create_payload_indexes(
         "crawl_timestamp",
     ]
     assert response.total_points == 1000
+    assert "_total_points" not in response.model_dump()
 
 
 @pytest.mark.asyncio
 async def test_create_payload_indexes_missing_collection(
     mock_client_manager, mock_vector_service, mock_context
 ):
+    """Raise ValueError when the requested collection cannot be found."""
+
     mock_vector_service.list_collections.return_value = []
 
     mock_mcp = MagicMock()
@@ -166,6 +173,8 @@ async def test_create_payload_indexes_missing_collection(
 
 @pytest.mark.asyncio
 async def test_list_payload_indexes(mock_client_manager, mock_context):
+    """Return summary metadata for existing payload indexes."""
+
     mock_mcp = MagicMock()
     registered = {}
     mock_mcp.tool.return_value = lambda func: registered.setdefault(func.__name__, func)
@@ -179,12 +188,15 @@ async def test_list_payload_indexes(mock_client_manager, mock_context):
     assert response.indexes_created == 5
     assert response.indexed_fields_count == 5
     assert response.total_points == 1000
+    assert "_total_points" not in response.model_dump()
 
 
 @pytest.mark.asyncio
 async def test_reindex_collection(
     mock_client_manager, mock_vector_service, mock_context
 ):
+    """Drop and recreate indexes while reporting post-state summary."""
+
     mock_mcp = MagicMock()
     registered = {}
     mock_mcp.tool.return_value = lambda func: registered.setdefault(func.__name__, func)
@@ -199,10 +211,13 @@ async def test_reindex_collection(
     mock_vector_service.ensure_payload_indexes.assert_awaited()
     assert response.reindexed_count == 5
     assert response.details["indexes_after"] == 5
+    assert "_total_points" not in response.details
 
 
 @pytest.mark.asyncio
 async def test_benchmark_filtered_search(mock_client_manager, mock_context):
+    """Benchmark filtered search and return performance metrics."""
+
     mock_mcp = MagicMock()
     registered = {}
     mock_mcp.tool.return_value = lambda func: registered.setdefault(func.__name__, func)
@@ -218,6 +233,7 @@ async def test_benchmark_filtered_search(mock_client_manager, mock_context):
 
     mock_client_manager.get_vector_store_service.assert_awaited()
     assert response.results_found == 2
+    assert "_total_points" not in response.model_dump()
     assert response.performance_estimate == "10-100x faster than unindexed"
     assert response.total_points == 5000
     assert response.indexed_fields == [


### PR DESCRIPTION
## Summary
- remove the security package aliases and update document ingestion to use `MLSecurityValidator` directly
- consolidate collection deletion on the canonical `drop_collection` method and adjust MCP tooling tests
- drop the legacy `_total_points` payload key and refresh payload indexing assertions to ensure the field stays absent

## Testing
- `uv run ruff check src/mcp_tools/tools/collection_management.py src/mcp_tools/tools/documents.py src/mcp_tools/tools/payload_indexing.py src/security/__init__.py src/services/vector_db/service.py tests/unit/mcp_tools/tools/test_collection_management.py tests/unit/mcp_tools/tools/test_documents_ingest.py tests/unit/mcp_tools/tools/test_payload_indexing.py`
- `uv run pylint src/mcp_tools/tools/collection_management.py src/mcp_tools/tools/documents.py src/mcp_tools/tools/payload_indexing.py src/security/__init__.py src/services/vector_db/service.py tests/unit/mcp_tools/tools/test_collection_management.py tests/unit/mcp_tools/tools/test_documents_ingest.py tests/unit/mcp_tools/tools/test_payload_indexing.py`
- `uv run python -m pytest -q tests/unit/mcp_tools/tools/test_payload_indexing.py tests/unit/mcp_tools/tools/test_collection_management.py tests/unit/mcp_tools/tools/test_documents_ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_68e59e4e4c58832ba3cbc8d1b8cdd171