### PR TITLE
refactor: unit tests for ClientManager and add RAG tool tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralized the MCP config and tool-module builders in `tests/unit/conftest.py`, parameterized streaming guard checks, and
   added coverage for empty hybrid-search results plus orchestrator partial-initialization guard rails.
 - Pinned the regression workflow `uv` dependency to `0.2.37` to stabilize CI setup.
+- Centralized RAG generator management through the shared ClientManager cache for MCP tooling and FastAPI dependencies, refreshing unit coverage to assert reuse and disabled-mode handling.
 
 ### Removed
 

--- a/docs/developers/architecture-and-orchestration.md
+++ b/docs/developers/architecture-and-orchestration.md
@@ -83,7 +83,7 @@ Key collaborators:
 | `DynamicToolDiscovery` | Enumerates MCP tools, classifies capabilities, filters by intent. |
 | `ToolExecutionService` | Executes tools via `langchain_mcp_adapters`, normalises errors/timeouts. |
 | `RetrievalHelper` | Performs dense+sparse retrieval through LangChain abstractions. |
-| `ClientManager` | Provides shared transports and configuration handles. |
+| `ClientManager` | Provides shared transports, configuration handles, and caches the shared RAG generator for FastAPI dependencies and MCP tooling. |
 
 `RunnableConfig` carries telemetry callbacks, correlation IDs, and per-request
 timeouts. Metrics (`agentic_graph_runs_total`, `agentic_graph_latency_ms`, etc.)

--- a/src/mcp_tools/tools/rag.py
+++ b/src/mcp_tools/tools/rag.py
@@ -4,8 +4,6 @@ Provide structured endpoints that build answers from vector search output using 
 configured language model stack.
 """
 
-# pylint: disable=duplicate-code
-
 import logging
 from typing import Any
 
@@ -13,25 +11,12 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from src.config import Config, get_config
+from src.infrastructure.client_manager import ClientManager
 from src.services.rag.generator import RAGGenerator
-from src.services.rag.models import RAGRequest
-from src.services.rag.utils import initialise_rag_generator
-from src.services.vector_db.service import VectorStoreService
+from src.services.rag.models import RAGRequest, RAGResult
 
 
 logger = logging.getLogger(__name__)
-
-
-async def _create_rag_generator(
-    config: Config,
-) -> tuple[RAGGenerator, VectorStoreService]:
-    """Initialise a RAG generator with an attached vector store."""
-
-    vector_store = VectorStoreService(config=config)
-    await vector_store.initialize()
-
-    rag_generator, _ = await initialise_rag_generator(config, vector_store)
-    return rag_generator, vector_store
 
 
 class RAGAnswerRequest(BaseModel):
@@ -84,7 +69,47 @@ class RAGMetricsResponse(BaseModel):
     )
 
 
-def register_tools(app: FastMCP) -> None:  # pylint: disable=too-many-statements
+def _ensure_rag_enabled(config: Config) -> None:
+    """Validate that RAG is enabled in the active configuration."""
+
+    if not config.rag.enable_rag:
+        msg = "RAG is not enabled in the configuration"
+        raise RuntimeError(msg)
+
+
+def _build_rag_service_request(request: RAGAnswerRequest) -> RAGRequest:
+    """Translate the MCP request model to the service-layer request."""
+
+    return RAGRequest(
+        query=request.query,
+        top_k=request.top_k,
+        filters=request.filters,
+        max_tokens=request.max_tokens,
+        temperature=request.temperature,
+        include_sources=request.include_sources,
+    )
+
+
+def _build_rag_answer_response(result: RAGResult) -> RAGAnswerResponse:
+    """Convert a RAG generator result into the MCP response schema."""
+
+    sources = None
+    if result.sources:
+        sources = [source.model_dump() for source in result.sources]
+
+    metrics = result.metrics.model_dump() if result.metrics else None
+
+    return RAGAnswerResponse(
+        answer=result.answer,
+        confidence_score=result.confidence_score,
+        sources_used=len(result.sources),
+        generation_time_ms=result.generation_time_ms,
+        sources=sources,
+        metrics=metrics,
+    )
+
+
+def register_tools(app: FastMCP, client_manager: ClientManager) -> None:
     """Register RAG tools with FastMCP app."""
 
     @app.tool()
@@ -103,50 +128,20 @@ def register_tools(app: FastMCP) -> None:  # pylint: disable=too-many-statements
 
         config = get_config()
 
-        # Check if RAG is enabled
-        if not config.rag.enable_rag:
-            msg = "RAG is not enabled in the configuration"
-            raise RuntimeError(msg)
+        _ensure_rag_enabled(config)
 
-        rag_generator = vector_store = None
         try:
-            rag_generator, vector_store = await _create_rag_generator(config)
+            rag_generator: RAGGenerator = await client_manager.get_rag_generator()
 
-            rag_request = RAGRequest(
-                query=request.query,
-                top_k=request.top_k,
-                filters=request.filters,
-                max_tokens=request.max_tokens,
-                temperature=request.temperature,
-                include_sources=request.include_sources,
-            )
-
+            rag_request = _build_rag_service_request(request)
             result = await rag_generator.generate_answer(rag_request)
 
-            sources = None
-            if result.sources:
-                sources = [source.model_dump() for source in result.sources]
-
-            metrics = result.metrics.model_dump() if result.metrics else None
-
-            return RAGAnswerResponse(
-                answer=result.answer,
-                confidence_score=result.confidence_score,
-                sources_used=len(result.sources),
-                generation_time_ms=result.generation_time_ms,
-                sources=sources,
-                metrics=metrics,
-            )
+            return _build_rag_answer_response(result)
 
         except Exception as e:  # pragma: no cover - runtime safety
             logger.exception("RAG answer generation failed")
             msg = "Failed to generate RAG answer"
             raise RuntimeError(msg) from e
-        finally:
-            if rag_generator and rag_generator.llm_client_available:
-                await rag_generator.cleanup()
-            if vector_store and vector_store.is_initialized():
-                await vector_store.cleanup()
 
     @app.tool()
     async def get_rag_metrics() -> RAGMetricsResponse:
@@ -163,13 +158,10 @@ def register_tools(app: FastMCP) -> None:  # pylint: disable=too-many-statements
         """
         config = get_config()
 
-        if not config.rag.enable_rag:
-            msg = "RAG is not enabled in the configuration"
-            raise RuntimeError(msg)
+        _ensure_rag_enabled(config)
 
-        rag_generator = vector_store = None
         try:
-            rag_generator, vector_store = await _create_rag_generator(config)
+            rag_generator: RAGGenerator = await client_manager.get_rag_generator()
             service_metrics = rag_generator.get_metrics()
             return RAGMetricsResponse(
                 generation_count=service_metrics.generation_count,
@@ -181,11 +173,6 @@ def register_tools(app: FastMCP) -> None:  # pylint: disable=too-many-statements
             logger.exception("Failed to get RAG metrics")
             msg = "Failed to get RAG metrics"
             raise RuntimeError(msg) from e
-        finally:
-            if rag_generator and rag_generator.llm_client_available:
-                await rag_generator.cleanup()
-            if vector_store and vector_store.is_initialized():
-                await vector_store.cleanup()
 
     @app.tool()
     async def test_rag_configuration() -> dict[str, Any]:
@@ -216,18 +203,12 @@ def register_tools(app: FastMCP) -> None:  # pylint: disable=too-many-statements
             results["error"] = "RAG is not enabled in configuration"
             return results
 
-        rag_generator = vector_store = None
         try:
-            rag_generator, vector_store = await _create_rag_generator(config)
+            await client_manager.get_rag_generator()
             results["connectivity_test"] = True
         except Exception as e:  # pragma: no cover - runtime safety
             results["error"] = str(e)
             logger.exception("RAG configuration test failed")
-        finally:
-            if rag_generator and rag_generator.llm_client_available:
-                await rag_generator.cleanup()
-            if vector_store and vector_store.is_initialized():
-                await vector_store.cleanup()
 
         return results
 

--- a/tests/unit/infrastructure/test_client_manager.py
+++ b/tests/unit/infrastructure/test_client_manager.py
@@ -1,482 +1,151 @@
-"""Unit tests for ClientManager with dependency injection container mocking."""
+"""Targeted tests for the infrastructure client manager."""
 
-import asyncio
-import time
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.config import Config
-from src.infrastructure.client_manager import ClientManager
-from src.infrastructure.container import ApplicationContainer
-from src.infrastructure.shared import CircuitBreaker, ClientHealth, ClientState
-from src.services.errors import APIError
+from tests.unit.stub_factories import register_rag_dependency_stubs
 
 
-class TestError(Exception):
-    """Custom exception for this module."""
+register_rag_dependency_stubs()
+
+crawl4ai_module = cast(Any, sys.modules["crawl4ai"])
 
 
-class MockClientProvider:
-    """Mock client provider for testing."""
+class _StubAsyncCrawler:
+    async def __aenter__(self) -> _StubAsyncCrawler:
+        """Support async context management for crawler stubs."""
 
-    def __init__(self, client=None):
-        self.client = client or AsyncMock()
-        self._healthy = True
+        return self
 
-    async def health_check(self):
-        return self._healthy
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Handle async context exit for crawler stubs."""
 
+        return None
 
-@pytest.fixture(autouse=True)
-async def ensure_clean_singleton():
-    """Ensure clean singleton state before and after each test."""
-    ClientManager.reset_singleton()
-    yield
-    ClientManager.reset_singleton()
+    async def start(self) -> None:
+        """Simulate crawler startup."""
 
+        return None
 
-@pytest.fixture
-def test_config():
-    """Create test configuration."""
-    config = Config()
-    config.openai.api_key = "test-openai-key"
-    config.firecrawl.api_key = "test-firecrawl-key"
-    config.cache.enable_caching = False
-    config.qdrant.url = "http://localhost:6333"
-    config.qdrant.api_key = "test-qdrant-key"
-    config.cache.redis_url = "redis://localhost:6379"
-    return config
+    async def close(self) -> None:
+        """Simulate crawler shutdown."""
+
+        return None
 
 
-@pytest.fixture
-async def mock_container(test_config):
-    """Create mock dependency injection container."""
-    container = ApplicationContainer()
-    container.config.override(test_config)
+crawl4ai_module.AsyncWebCrawler = _StubAsyncCrawler
 
-    # Create and override providers with mocks
-    mock_openai_provider = MockClientProvider(AsyncMock())
-    mock_qdrant_provider = MockClientProvider(AsyncMock())
-    mock_redis_provider = MockClientProvider(AsyncMock())
-    mock_firecrawl_provider = MockClientProvider(AsyncMock())
-    mock_http_provider = MockClientProvider(AsyncMock())
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "src/infrastructure/client_manager.py"
+_spec = importlib.util.spec_from_file_location("client_manager_under_test", MODULE_PATH)
+assert _spec and _spec.loader
+client_manager_module = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = client_manager_module
+_spec.loader.exec_module(client_manager_module)  # type: ignore[arg-type]
 
-    container.openai_provider.override(mock_openai_provider)
-    container.qdrant_provider.override(mock_qdrant_provider)
-    container.redis_provider.override(mock_redis_provider)
-    container.firecrawl_provider.override(mock_firecrawl_provider)
-    container.http_provider.override(mock_http_provider)
-
-    # Mock parallel processing system
-    mock_parallel_system = AsyncMock()
-    mock_parallel_system.get_system_status.return_value = {"status": "healthy"}
-    container.parallel_processing_system.override(mock_parallel_system)
-
-    return container
+ClientManager = client_manager_module.ClientManager
 
 
-@pytest.fixture
-async def client_manager_with_mocks(mock_container):
-    """Create ClientManager with mocked dependency injection container."""
+@pytest.fixture()
+async def client_manager(monkeypatch: pytest.MonkeyPatch) -> ClientManager:
+    """Create a client manager instance with stubbed dependencies."""
+
+    monkeypatch.setattr(
+        client_manager_module,
+        "get_config",
+        lambda: types.SimpleNamespace(
+            fastembed=types.SimpleNamespace(model="stub"),
+            qdrant=types.SimpleNamespace(collection_name="documents"),
+            rag=types.SimpleNamespace(
+                model="stub-model",
+                temperature=0.1,
+                max_tokens=256,
+                include_sources=True,
+                max_results_for_context=5,
+                include_confidence_score=True,
+            ),
+        ),
+    )
+    manager = ClientManager()
+    await manager.initialize()
+    yield manager
+    await manager.cleanup()
     ClientManager.reset_singleton()
 
-    with patch(
-        "src.infrastructure.client_manager.get_container", return_value=mock_container
+
+@pytest.mark.asyncio()
+async def test_get_rag_generator_caches_instance(client_manager: ClientManager) -> None:
+    """get_rag_generator should initialise once and reuse the instance."""
+
+    vector_store = MagicMock()
+    rag_generator = MagicMock()
+    rag_generator.cleanup = AsyncMock()
+    with (
+        patch.object(
+            client_manager,
+            "get_vector_store_service",
+            AsyncMock(return_value=vector_store),
+        ) as get_vector_store,
+        patch.object(
+            client_manager_module,
+            "initialise_rag_generator",
+            AsyncMock(return_value=(rag_generator, MagicMock())),
+        ) as initialise,
     ):
-        manager = ClientManager()
-        await manager.initialize()
+        first = await client_manager.get_rag_generator()
+        second = await client_manager.get_rag_generator()
 
-        yield manager
+    assert first is rag_generator
+    assert second is rag_generator
+    get_vector_store.assert_awaited_once()
+    initialise.assert_awaited_once_with(
+        client_manager_module.get_config(), vector_store
+    )
 
-        await manager.cleanup()
-        ClientManager.reset_singleton()
 
+@pytest.mark.asyncio()
+async def test_cleanup_resets_cached_services(client_manager: ClientManager) -> None:
+    """cleanup should dispose of cached rag generator and vector store services."""
 
-class TestClientState:
-    """Test ClientState enum values."""
+    vector_store = MagicMock()
+    vector_store.cleanup = AsyncMock()
+    rag_generator = MagicMock()
+    rag_generator.cleanup = AsyncMock()
 
-    def test_client_state_values(self):
-        """Verify all expected states exist."""
-        assert ClientState.UNINITIALIZED.value == "uninitialized"
-        assert ClientState.HEALTHY.value == "healthy"
-        assert ClientState.DEGRADED.value == "degraded"
-        assert ClientState.FAILED.value == "failed"
+    client_manager._vector_store_service = vector_store
+    client_manager._rag_generator = rag_generator
 
-    def test_client_state_enum_completeness(self):
-        """Verify enum contains all expected members."""
-        expected_states = {"UNINITIALIZED", "HEALTHY", "DEGRADED", "FAILED"}
-        actual_states = {state.name for state in ClientState}
-        assert actual_states == expected_states
+    await client_manager.cleanup()
 
+    vector_store.cleanup.assert_awaited_once()
+    rag_generator.cleanup.assert_awaited_once()
+    assert client_manager._vector_store_service is None
+    assert client_manager._rag_generator is None
 
-class TestClientHealth:
-    """Test ClientHealth dataclass."""
 
-    def test_client_health_initialization(self):
-        """Test basic initialization."""
-        health = ClientHealth(
-            state=ClientState.HEALTHY,
-            last_check=time.time(),
-            last_error=None,
-            consecutive_failures=0,
-        )
-        assert health.state == ClientState.HEALTHY
-        assert health.last_error is None
-        assert health.consecutive_failures == 0
+@pytest.mark.asyncio()
+async def test_get_rag_generator_returns_initialised_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_rag_generator should return a cached generator when preset."""
 
-    def test_client_health_with_error(self):
-        """Test health with error state."""
-        error_msg = "Connection failed"
-        health = ClientHealth(
-            state=ClientState.FAILED,
-            last_check=time.time(),
-            last_error=error_msg,
-            consecutive_failures=3,
-        )
-        assert health.state == ClientState.FAILED
-        assert health.last_error == error_msg
-        assert health.consecutive_failures == 3
+    manager = ClientManager()
+    await manager.initialize()
 
+    rag_generator = MagicMock()
+    rag_generator.cleanup = AsyncMock()
+    manager._rag_generator = rag_generator
 
-class TestCircuitBreaker:
-    """Test CircuitBreaker functionality."""
+    result = await manager.get_rag_generator()
 
-    @pytest.fixture
-    def circuit_breaker(self):
-        """Create circuit breaker with test parameters."""
-        return CircuitBreaker(
-            failure_threshold=3,
-            recovery_timeout=1.0,
-            half_open_requests=1,
-        )
-
-    @pytest.mark.asyncio
-    async def test_circuit_breaker_healthy_state(self, circuit_breaker):
-        """Test circuit breaker in healthy state allows calls."""
-
-        async def success_func():
-            return "success"
-
-        result = await circuit_breaker.call(success_func)
-        assert result == "success"
-        assert circuit_breaker.state == ClientState.HEALTHY
-
-    @pytest.mark.asyncio
-    async def test_circuit_breaker_opens_after_failures(self, circuit_breaker):
-        """Test circuit breaker opens after threshold failures."""
-
-        async def failing_func():
-            raise ConnectionError("Test connection failure")
-
-        for _ in range(3):
-            with pytest.raises(ConnectionError):
-                await circuit_breaker.call(failing_func)
-
-        assert circuit_breaker.state == ClientState.FAILED
-
-        async def success_func():
-            return "success"
-
-        with pytest.raises(APIError, match="Circuit breaker is open"):
-            await circuit_breaker.call(success_func)
-
-    @pytest.mark.asyncio
-    async def test_circuit_breaker_recovery(self, circuit_breaker):
-        """Test circuit breaker recovery after timeout."""
-
-        async def failing_func():
-            raise ConnectionError("Test connection failure")
-
-        async def success_func():
-            return "success"
-
-        for _ in range(3):
-            with pytest.raises(ConnectionError):
-                await circuit_breaker.call(failing_func)
-
-        assert circuit_breaker.state == ClientState.FAILED
-
-        await asyncio.sleep(1.1)
-
-        result = await circuit_breaker.call(success_func)
-        assert result == "success"
-        assert circuit_breaker.state == ClientState.HEALTHY
-
-
-class TestClientManagerInitialization:
-    """Test ClientManager initialization and singleton pattern."""
-
-    @pytest.mark.asyncio
-    async def test_singleton_pattern(self):
-        """Test that ClientManager follows singleton pattern."""
-        ClientManager.reset_singleton()
-
-        with patch(
-            "src.infrastructure.client_manager.get_container"
-        ) as mock_get_container:
-            mock_container = MagicMock()
-            mock_get_container.return_value = mock_container
-
-            manager1 = ClientManager()
-            manager2 = ClientManager()
-
-            assert manager1 is manager2
-
-        ClientManager.reset_singleton()
-
-    @pytest.mark.asyncio
-    async def test_initialization_with_dependency_injection(
-        self, client_manager_with_mocks
-    ):
-        """Test initialization with dependency injection container."""
-        assert client_manager_with_mocks.is_initialized
-        assert client_manager_with_mocks._providers is not None
-        assert len(client_manager_with_mocks._providers) == 5
-
-
-class TestClientManagerClientAccess:
-    """Test client access methods using dependency injection."""
-
-    @pytest.mark.asyncio
-    async def test_get_qdrant_client(self, client_manager_with_mocks):
-        """Test Qdrant client access through dependency injection."""
-        client = await client_manager_with_mocks.get_qdrant_client()
-        assert client is not None
-
-    @pytest.mark.asyncio
-    async def test_get_openai_client(self, client_manager_with_mocks):
-        """Test OpenAI client access through dependency injection."""
-        client = await client_manager_with_mocks.get_openai_client()
-        assert client is not None
-
-    @pytest.mark.asyncio
-    async def test_get_redis_client(self, client_manager_with_mocks):
-        """Test Redis client access through dependency injection."""
-        client = await client_manager_with_mocks.get_redis_client()
-        assert client is not None
-
-    @pytest.mark.asyncio
-    async def test_get_firecrawl_client(self, client_manager_with_mocks):
-        """Test Firecrawl client access through dependency injection."""
-        client = await client_manager_with_mocks.get_firecrawl_client()
-        assert client is not None
-
-    @pytest.mark.asyncio
-    async def test_get_http_client(self, client_manager_with_mocks):
-        """Test HTTP client access through dependency injection."""
-        client = await client_manager_with_mocks.get_http_client()
-        assert client is not None
-
-
-class TestClientManagerServiceIntegration:
-    """Test service integration methods."""
-
-    @pytest.mark.asyncio
-    async def test_get_vector_store_service(self, client_manager_with_mocks):
-        """Test vector store service creation and caching."""
-        with (
-            patch(
-                "src.infrastructure.client_manager.FastEmbedProvider"
-            ) as mock_embed_cls,
-            patch(
-                "src.infrastructure.client_manager.VectorStoreService"
-            ) as mock_service_cls,
-        ):
-            mock_embed = MagicMock()
-            mock_embed_cls.return_value = mock_embed
-
-            mock_service = MagicMock()
-            mock_service.initialize = AsyncMock()
-            mock_service.cleanup = AsyncMock()
-            mock_service_cls.return_value = mock_service
-
-            service1 = await client_manager_with_mocks.get_vector_store_service()
-            assert service1 is mock_service
-            assert mock_service.initialize.await_count == 1
-
-            service2 = await client_manager_with_mocks.get_vector_store_service()
-            assert service2 is service1
-            assert mock_service.initialize.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_get_parallel_processing_system(self, client_manager_with_mocks):
-        """Test parallel processing system access."""
-        system = await client_manager_with_mocks.get_parallel_processing_system()
-        assert system is not None
-
-    @pytest.mark.asyncio
-    async def test_get_browser_automation_router(self, client_manager_with_mocks):
-        """Test browser automation router creation and caching."""
-        with patch(
-            "src.infrastructure.client_manager.AutomationRouter"
-        ) as mock_router_class:
-            mock_router = MagicMock()
-            mock_router.initialize = AsyncMock()
-            mock_router_class.return_value = mock_router
-
-            router1 = await client_manager_with_mocks.get_browser_automation_router()
-            assert router1 is mock_router
-            mock_router.initialize.assert_awaited_once()
-
-            router2 = await client_manager_with_mocks.get_browser_automation_router()
-            assert router2 is router1
-            mock_router.initialize.assert_awaited_once()
-
-
-class TestClientManagerHealthAndStatus:
-    """Test health monitoring and status methods."""
-
-    @pytest.mark.asyncio
-    async def test_get_health_status(self, client_manager_with_mocks):
-        """Test health status retrieval."""
-        with patch(
-            "src.infrastructure.client_manager.deps_get_health_status",
-            new_callable=AsyncMock,
-        ) as mock_health_func:
-            mock_health_func.return_value = {"test": "healthy"}
-
-            status = await client_manager_with_mocks.get_health_status()
-            assert status == {"test": "healthy"}
-            mock_health_func.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_get_overall_health(self, client_manager_with_mocks):
-        """Test overall health retrieval."""
-        with patch(
-            "src.infrastructure.client_manager.deps_get_overall_health",
-            new_callable=AsyncMock,
-        ) as mock_overall_func:
-            mock_overall_func.return_value = {"healthy": True}
-
-            health = await client_manager_with_mocks.get_overall_health()
-            assert health == {"healthy": True}
-            mock_overall_func.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_get_service_status(self, client_manager_with_mocks):
-        """Test service status information."""
-        status = await client_manager_with_mocks.get_service_status()
-
-        assert isinstance(status, dict)
-        assert "initialized" in status
-        assert "mode" in status
-        assert "providers" in status
-        assert status["mode"] == "function_based_dependencies"
-
-
-class TestClientManagerContextManager:
-    """Test context manager functionality."""
-
-    @pytest.mark.asyncio
-    async def test_async_context_manager(self, client_manager_with_mocks):
-        """Test async context manager protocol."""
-        async with client_manager_with_mocks as manager:
-            assert manager.is_initialized
-
-        assert not client_manager_with_mocks._initialized
-
-    @pytest.mark.asyncio
-    async def test_managed_client_context(self, client_manager_with_mocks):
-        """Test managed client context manager."""
-        async with client_manager_with_mocks.managed_client("qdrant") as client:
-            assert client is not None
-
-    @pytest.mark.asyncio
-    async def test_managed_client_invalid_type(self, client_manager_with_mocks):
-        """Test managed client with invalid type raises ValueError."""
-        with pytest.raises(ValueError, match="Unknown client type"):
-            async with client_manager_with_mocks.managed_client("invalid_type"):
-                pass
-
-
-class TestClientManagerCleanup:
-    """Test cleanup and resource management."""
-
-    @pytest.mark.asyncio
-    async def test_cleanup_resets_state(self, client_manager_with_mocks):
-        """Test that cleanup properly resets manager state."""
-        assert client_manager_with_mocks.is_initialized
-
-        await client_manager_with_mocks.cleanup()
-
-        assert not client_manager_with_mocks._initialized
-        assert client_manager_with_mocks._providers == {}
-        assert client_manager_with_mocks._parallel_processing_system is None
-
-    @pytest.mark.asyncio
-    async def test_cleanup_with_vector_store_service(self, client_manager_with_mocks):
-        """Test cleanup when vector store service exists."""
-        with (
-            patch(
-                "src.infrastructure.client_manager.FastEmbedProvider"
-            ) as mock_embed_cls,
-            patch(
-                "src.infrastructure.client_manager.VectorStoreService"
-            ) as mock_service_cls,
-        ):
-            mock_embed_cls.return_value = MagicMock()
-
-            mock_service = MagicMock()
-            mock_service.initialize = AsyncMock()
-            mock_service.cleanup = AsyncMock()
-            mock_service_cls.return_value = mock_service
-
-            await client_manager_with_mocks.get_vector_store_service()
-            assert client_manager_with_mocks._vector_store_service is mock_service
-
-            await client_manager_with_mocks.cleanup()
-            mock_service.cleanup.assert_awaited_once()
-
-
-class TestClientManagerErrorHandling:
-    """Test error handling and resilience."""
-
-    @pytest.mark.asyncio
-    async def test_get_qdrant_client_provider_error(self, client_manager_with_mocks):
-        """Test error when Qdrant provider is not available."""
-        original_provider = client_manager_with_mocks._providers.get("qdrant")
-        client_manager_with_mocks._providers["qdrant"] = None
-
-        try:
-            with pytest.raises(APIError, match="Qdrant client provider not available"):
-                await client_manager_with_mocks.get_qdrant_client()
-        finally:
-            if original_provider:
-                client_manager_with_mocks._providers["qdrant"] = original_provider
-
-    @pytest.mark.asyncio
-    async def test_get_redis_client_provider_error(self, client_manager_with_mocks):
-        """Test error when Redis provider is not available."""
-        original_provider = client_manager_with_mocks._providers.get("redis")
-        client_manager_with_mocks._providers["redis"] = None
-
-        try:
-            with pytest.raises(APIError, match="Redis client provider not available"):
-                await client_manager_with_mocks.get_redis_client()
-        finally:
-            if original_provider:
-                client_manager_with_mocks._providers["redis"] = original_provider
-
-    @pytest.mark.asyncio
-    async def test_get_http_client_provider_error(self, client_manager_with_mocks):
-        """Test error when HTTP provider is not available."""
-        original_provider = client_manager_with_mocks._providers.get("http")
-        client_manager_with_mocks._providers["http"] = None
-
-        try:
-            with pytest.raises(APIError, match="HTTP client provider not available"):
-                await client_manager_with_mocks.get_http_client()
-        finally:
-            if original_provider:
-                client_manager_with_mocks._providers["http"] = original_provider
-
-
-class TestClientManagerFactoryMethods:
-    """Test factory methods for ClientManager creation."""
-
-    @pytest.mark.asyncio
-    async def test_from_unified_config(self):
-        """Test factory method for creating from unified config."""
-        manager = ClientManager.from_unified_config()
-        assert isinstance(manager, ClientManager)
+    assert result is rag_generator
+    await manager.cleanup()
+    ClientManager.reset_singleton()

--- a/tests/unit/mcp_tools/tools/test_rag.py
+++ b/tests/unit/mcp_tools/tools/test_rag.py
@@ -1,0 +1,219 @@
+"""Tests for the RAG MCP tool module."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.rag.models import (
+    AnswerMetrics,
+    RAGResult,
+    RAGServiceMetrics,
+    SourceAttribution,
+)
+from tests.unit.stub_factories import register_rag_dependency_stubs
+
+
+register_rag_dependency_stubs()
+
+client_manager_stub = cast(Any, types.ModuleType("src.infrastructure.client_manager"))
+client_manager_stub.ClientManager = type("ClientManager", (), {})
+sys.modules.setdefault("src.infrastructure.client_manager", client_manager_stub)
+
+crawl4ai_stub = cast(Any, sys.modules["crawl4ai"])
+
+
+class _StubAsyncCrawler:
+    async def start(self) -> None:
+        """Simulate asynchronous crawler start."""
+
+        return None
+
+    async def close(self) -> None:
+        """Simulate asynchronous crawler shutdown."""
+
+        return None
+
+
+crawl4ai_stub.AsyncWebCrawler = _StubAsyncCrawler
+
+ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = ROOT / "src/mcp_tools/tools/rag.py"
+_spec = importlib.util.spec_from_file_location("rag_under_test", MODULE_PATH)
+assert _spec and _spec.loader
+rag_module = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = rag_module
+_spec.loader.exec_module(rag_module)  # type: ignore[arg-type]
+
+RAGAnswerRequest = rag_module.RAGAnswerRequest
+RAGMetricsResponse = rag_module.RAGMetricsResponse
+register_tools = rag_module.register_tools
+
+sys.modules.pop("src.infrastructure.client_manager", None)
+
+
+@pytest.fixture()
+def configured_app(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Provide a configuration object with RAG enabled for tests."""
+
+    config = SimpleNamespace(
+        rag=SimpleNamespace(
+            enable_rag=True,
+            include_sources=True,
+            max_tokens=256,
+            temperature=0.2,
+            model="test-model",
+            max_context_length=4096,
+        )
+    )
+    monkeypatch.setattr(rag_module, "get_config", lambda: config)
+    return config
+
+
+@pytest.fixture()
+def mock_client_manager() -> MagicMock:
+    """Create a client manager mock exposing get_rag_generator."""
+
+    manager = MagicMock()
+    manager.get_rag_generator = AsyncMock()
+    return manager
+
+
+@pytest.fixture()
+def registered_tools(
+    configured_app: SimpleNamespace, mock_client_manager: MagicMock
+) -> dict[str, Callable]:
+    """Register RAG tools against a mocked FastMCP instance."""
+
+    del configured_app
+    mock_app = MagicMock()
+    tools: dict[str, Callable] = {}
+
+    def capture(func: Callable) -> Callable:
+        tools[func.__name__] = func
+        return func
+
+    mock_app.tool.return_value = capture
+    register_tools(mock_app, mock_client_manager)
+    return tools
+
+
+@pytest.mark.asyncio()
+async def test_generate_rag_answer_uses_shared_generator(
+    configured_app: SimpleNamespace,
+    registered_tools: dict[str, Callable],
+    mock_client_manager: MagicMock,
+) -> None:
+    """generate_rag_answer should reuse the shared client manager generator."""
+
+    del configured_app
+    rag_generator = MagicMock()
+    rag_generator.generate_answer = AsyncMock(
+        return_value=RAGResult(
+            answer="Answer",
+            confidence_score=0.9,
+            sources=[
+                SourceAttribution(
+                    source_id="doc-1",
+                    title="Document 1",
+                    url="https://example.com/doc-1",
+                    excerpt="snippet",
+                    score=0.8,
+                )
+            ],
+            generation_time_ms=42.0,
+            metrics=AnswerMetrics(
+                total_tokens=50,
+                prompt_tokens=20,
+                completion_tokens=30,
+                generation_time_ms=42.0,
+            ),
+        )
+    )
+    rag_generator.cleanup = AsyncMock()
+    mock_client_manager.get_rag_generator.return_value = rag_generator
+
+    request = RAGAnswerRequest(query="What is RAG?", top_k=3)
+    response = await registered_tools["generate_rag_answer"](request)
+
+    mock_client_manager.get_rag_generator.assert_awaited_once()
+    rag_generator.generate_answer.assert_awaited_once()
+    rag_generator.cleanup.assert_not_called()
+    assert response.answer == "Answer"
+    assert response.confidence_score == 0.9
+    assert response.sources_used == 1
+    assert response.sources is not None and response.sources[0]["source_id"] == "doc-1"
+
+
+@pytest.mark.asyncio()
+async def test_get_rag_metrics_returns_service_metrics(
+    configured_app: SimpleNamespace,
+    registered_tools: dict[str, Callable],
+    mock_client_manager: MagicMock,
+) -> None:
+    """get_rag_metrics should surface metrics from the shared generator."""
+
+    del configured_app
+    rag_generator = MagicMock()
+    rag_generator.get_metrics.return_value = RAGServiceMetrics(
+        generation_count=10,
+        avg_generation_time_ms=25.0,
+        total_generation_time_ms=250.0,
+    )
+    mock_client_manager.get_rag_generator.return_value = rag_generator
+
+    response = await registered_tools["get_rag_metrics"]()
+
+    mock_client_manager.get_rag_generator.assert_awaited_once()
+    rag_generator.get_metrics.assert_called_once()
+    assert isinstance(response, RAGMetricsResponse)
+    assert response.generation_count == 10
+    assert response.avg_generation_time_ms == 25.0
+
+
+@pytest.mark.asyncio()
+async def test_test_rag_configuration_confirms_connectivity(
+    configured_app: SimpleNamespace,
+    registered_tools: dict[str, Callable],
+    mock_client_manager: MagicMock,
+) -> None:
+    """test_rag_configuration should validate connectivity without cleanup."""
+
+    del configured_app
+    rag_generator = MagicMock()
+    rag_generator.cleanup = AsyncMock()
+    mock_client_manager.get_rag_generator.return_value = rag_generator
+
+    results = await registered_tools["test_rag_configuration"]()
+
+    mock_client_manager.get_rag_generator.assert_awaited_once()
+    rag_generator.cleanup.assert_not_called()
+    assert results["rag_enabled"] is True
+    assert results["connectivity_test"] is True
+    assert results["error"] is None
+
+
+@pytest.mark.asyncio()
+async def test_generate_rag_answer_errors_when_rag_disabled(
+    configured_app: SimpleNamespace,
+    registered_tools: dict[str, Callable],
+    mock_client_manager: MagicMock,
+) -> None:
+    """generate_rag_answer should fail fast when configuration disables RAG."""
+
+    configured_app.rag.enable_rag = False
+
+    request = RAGAnswerRequest(query="Is RAG enabled?")
+
+    with pytest.raises(RuntimeError, match="RAG is not enabled"):
+        await registered_tools["generate_rag_answer"](request)
+
+    mock_client_manager.get_rag_generator.assert_not_called()

--- a/tests/unit/stub_factories.py
+++ b/tests/unit/stub_factories.py
@@ -1,0 +1,304 @@
+"""Utilities for registering dependency stubs used in unit tests."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterable
+from typing import Any, cast
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    """Return an existing module or register a new stub module."""
+
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _set_attributes(module: types.ModuleType, attributes: dict[str, object]) -> None:
+    """Assign attributes to a module if they are missing."""
+
+    for attr_name, attr_value in attributes.items():
+        if not hasattr(module, attr_name):
+            setattr(module, attr_name, attr_value)
+
+
+class _ChatPromptTemplate:
+    """Simple stub for LangChain chat prompt templates."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.messages: list[object] = []
+        self.options = dict(kwargs)
+
+    @classmethod
+    def from_messages(
+        cls, messages: Iterable[object] | None = None, **kwargs: object
+    ) -> _ChatPromptTemplate:
+        template = cls(**kwargs)
+        template.messages = list(messages or [])
+        return template
+
+
+def _register_client_stubs() -> None:
+    """Register stubs for client SDKs leveraged by the RAG pipeline."""
+
+    firecrawl = _ensure_module("firecrawl")
+    _set_attributes(
+        firecrawl,
+        {"AsyncFirecrawlApp": type("AsyncFirecrawlApp", (), {})},
+    )
+
+    openai = _ensure_module("openai")
+    _set_attributes(openai, {"AsyncOpenAI": type("AsyncOpenAI", (), {})})
+
+    langchain_openai = _ensure_module("langchain_openai")
+    _set_attributes(langchain_openai, {"ChatOpenAI": type("ChatOpenAI", (), {})})
+
+    qdrant = _ensure_module("langchain_qdrant")
+    _set_attributes(
+        qdrant,
+        {
+            "QdrantVectorStore": type("QdrantVectorStore", (), {}),
+            "RetrievalMode": type("RetrievalMode", (), {}),
+            "FastEmbedSparse": type("FastEmbedSparse", (), {}),
+        },
+    )
+
+
+def _register_langchain_core_stubs() -> None:
+    """Register core LangChain modules required for RAG tests."""
+
+    langchain = cast(Any, _ensure_module("langchain"))
+    retrievers = cast(Any, _ensure_module("langchain.retrievers"))
+    document_compressors = cast(
+        Any, _ensure_module("langchain.retrievers.document_compressors")
+    )
+    _set_attributes(
+        document_compressors,
+        {
+            "DocumentCompressorPipeline": type("DocumentCompressorPipeline", (), {}),
+            "EmbeddingsFilter": type("EmbeddingsFilter", (), {}),
+        },
+    )
+    retrievers.document_compressors = document_compressors
+    langchain.retrievers = retrievers
+
+    callbacks_manager = cast(Any, _ensure_module("langchain_core.callbacks.manager"))
+    _set_attributes(
+        callbacks_manager,
+        {
+            "AsyncCallbackManagerForRetrieverRun": type(
+                "AsyncCallbackManagerForRetrieverRun", (), {}
+            ),
+            "CallbackManagerForRetrieverRun": type(
+                "CallbackManagerForRetrieverRun", (), {}
+            ),
+            "AsyncCallbackManager": type("AsyncCallbackManager", (), {}),
+            "CallbackManager": type("CallbackManager", (), {}),
+        },
+    )
+
+    callbacks_root = cast(Any, _ensure_module("langchain_core.callbacks"))
+    _set_attributes(
+        callbacks_root,
+        {
+            "AsyncCallbackManager": type("AsyncCallbackManager", (), {}),
+            "CallbackManager": type("CallbackManager", (), {}),
+            "BaseCallbackManager": type("BaseCallbackManager", (), {}),
+            "Callbacks": type("Callbacks", (), {}),
+            "AsyncCallbackManagerForToolRun": type(
+                "AsyncCallbackManagerForToolRun", (), {}
+            ),
+            "CallbackManagerForToolRun": type("CallbackManagerForToolRun", (), {}),
+        },
+    )
+    if not hasattr(callbacks_root, "__path__"):
+        callbacks_root.__path__ = []  # type: ignore[attr-defined]
+
+    callbacks_base = cast(Any, _ensure_module("langchain_core.callbacks.base"))
+    _set_attributes(
+        callbacks_base,
+        {
+            "BaseCallbackManager": type("BaseCallbackManager", (), {}),
+            "AsyncCallbackHandler": type("AsyncCallbackHandler", (), {}),
+            "BaseCallbackHandler": type("BaseCallbackHandler", (), {}),
+        },
+    )
+
+    messages = cast(Any, _ensure_module("langchain_core.messages"))
+    _set_attributes(
+        messages,
+        {
+            "AIMessage": type("AIMessage", (), {}),
+            "HumanMessage": type("HumanMessage", (), {}),
+        },
+    )
+
+    tools = cast(Any, _ensure_module("langchain_core.tools"))
+    if not hasattr(tools, "__path__"):
+        tools.__path__ = []  # type: ignore[attr-defined]
+    _set_attributes(
+        tools,
+        {
+            "BaseTool": type("BaseTool", (), {}),
+            "InjectedToolArg": type("InjectedToolArg", (), {}),
+            "StructuredTool": type("StructuredTool", (), {}),
+            "Tool": type("Tool", (), {}),
+            "ToolException": type("ToolException", (), {}),
+        },
+    )
+
+    tools_base = cast(Any, _ensure_module("langchain_core.tools.base"))
+    _set_attributes(
+        tools_base,
+        {
+            "BaseTool": type("BaseTool", (), {}),
+            "get_all_basemodel_annotations": lambda *args, **kwargs: {},
+        },
+    )
+
+    prompts = cast(Any, _ensure_module("langchain_core.prompts"))
+    _set_attributes(prompts, {"ChatPromptTemplate": _ChatPromptTemplate})
+
+    documents = cast(Any, _ensure_module("langchain_core.documents"))
+    _set_attributes(documents, {"Document": type("Document", (), {})})
+
+    documents_base = cast(Any, _ensure_module("langchain_core.documents.base"))
+    _set_attributes(documents_base, {"Blob": type("Blob", (), {})})
+
+    retrievers_core = cast(Any, _ensure_module("langchain_core.retrievers"))
+    _set_attributes(retrievers_core, {"BaseRetriever": type("BaseRetriever", (), {})})
+
+    text_splitters = cast(Any, _ensure_module("langchain_text_splitters"))
+    _set_attributes(
+        text_splitters,
+        {
+            "RecursiveCharacterTextSplitter": type(
+                "RecursiveCharacterTextSplitter", (), {}
+            ),
+        },
+    )
+
+    if not hasattr(langchain, "__path__"):
+        langchain.__path__ = []  # type: ignore[attr-defined]
+
+
+def _register_langchain_community_stubs() -> None:
+    """Register LangChain community modules used by the RAG pipeline."""
+
+    community = cast(Any, _ensure_module("langchain_community"))
+    community_embeddings = cast(Any, _ensure_module("langchain_community.embeddings"))
+    fastembed = cast(Any, _ensure_module("langchain_community.embeddings.fastembed"))
+    _set_attributes(
+        fastembed,
+        {"FastEmbedEmbeddings": type("FastEmbedEmbeddings", (), {})},
+    )
+    community_embeddings.fastembed = fastembed
+    community_embeddings.FastEmbedEmbeddings = fastembed.FastEmbedEmbeddings
+    community.embeddings = community_embeddings
+
+    transformers = cast(
+        Any, _ensure_module("langchain_community.document_transformers")
+    )
+    _set_attributes(
+        transformers,
+        {"EmbeddingsRedundantFilter": type("EmbeddingsRedundantFilter", (), {})},
+    )
+
+    if not hasattr(community, "__path__"):
+        community.__path__ = []  # type: ignore[attr-defined]
+
+
+def _register_crawl4ai_stubs() -> None:
+    """Register Crawl4AI modules required for crawling stubs."""
+
+    crawl4ai = _ensure_module("crawl4ai")
+    _set_attributes(
+        crawl4ai,
+        {
+            "AsyncWebCrawler": type("AsyncWebCrawler", (), {}),
+            "CacheMode": type("CacheMode", (), {"BYPASS": "bypass"}),
+            "BrowserConfig": type("BrowserConfig", (), {}),
+            "CrawlerRunConfig": type("CrawlerRunConfig", (), {}),
+            "MemoryAdaptiveDispatcher": type("MemoryAdaptiveDispatcher", (), {}),
+            "DefaultMarkdownGenerator": type("DefaultMarkdownGenerator", (), {}),
+            "LinkPreviewConfig": type("LinkPreviewConfig", (), {}),
+            "RateLimiter": type("RateLimiter", (), {}),
+            "RunConfig": type("RunConfig", (), {"clone": lambda self, **_: self}),
+            "CrawlerMonitor": type("CrawlerMonitor", (), {}),
+        },
+    )
+
+    crawl4ai_models = _ensure_module("crawl4ai.models")
+    _set_attributes(crawl4ai_models, {"CrawlResult": type("CrawlResult", (), {})})
+
+    async_dispatcher = _ensure_module("crawl4ai.async_dispatcher")
+    _set_attributes(
+        async_dispatcher, {"SemaphoreDispatcher": type("SemaphoreDispatcher", (), {})}
+    )
+
+    crawl4ai_deep = _ensure_module("crawl4ai.deep_crawling")
+    _set_attributes(
+        crawl4ai_deep,
+        {
+            "BestFirstCrawlingStrategy": type("BestFirstCrawlingStrategy", (), {}),
+            "BFSDeepCrawlStrategy": type("BFSDeepCrawlStrategy", (), {}),
+        },
+    )
+
+    filters_module = _ensure_module("crawl4ai.deep_crawling.filters")
+    _set_attributes(
+        filters_module,
+        {
+            "ContentRelevanceFilter": type("ContentRelevanceFilter", (), {}),
+            "ContentTypeFilter": type("ContentTypeFilter", (), {}),
+            "DomainFilter": type("DomainFilter", (), {}),
+            "FilterChain": type("FilterChain", (), {}),
+            "SEOFilter": type("SEOFilter", (), {}),
+            "URLFilter": type("URLFilter", (), {}),
+            "URLPatternFilter": type("URLPatternFilter", (), {}),
+        },
+    )
+
+    scorers_module = _ensure_module("crawl4ai.deep_crawling.scorers")
+    _set_attributes(
+        scorers_module,
+        {"KeywordRelevanceScorer": type("KeywordRelevanceScorer", (), {})},
+    )
+
+    content_filter = _ensure_module("crawl4ai.content_filter_strategy")
+    _set_attributes(
+        content_filter,
+        {
+            "BM25ContentFilter": type("BM25ContentFilter", (), {}),
+            "PruningContentFilter": type("PruningContentFilter", (), {}),
+        },
+    )
+
+    for namespace in ("langchain_core", "langchain_community", "crawl4ai"):
+        package = _ensure_module(namespace)
+        if not hasattr(package, "__path__"):
+            package.__path__ = []  # type: ignore[attr-defined]
+
+
+def _register_miscellaneous_stubs() -> None:
+    """Register additional third-party stubs referenced by the tests."""
+
+    tiktoken = _ensure_module("tiktoken")
+    _set_attributes(tiktoken, {})
+
+    bs4_module = _ensure_module("bs4")
+    _set_attributes(bs4_module, {"BeautifulSoup": type("BeautifulSoup", (), {})})
+
+
+def register_rag_dependency_stubs() -> None:
+    """Register all optional dependency stubs needed for the RAG tests."""
+
+    _register_client_stubs()
+    _register_langchain_core_stubs()
+    _register_langchain_community_stubs()
+    _register_crawl4ai_stubs()
+    _register_miscellaneous_stubs()


### PR DESCRIPTION
- Simplified and targeted tests for the infrastructure ClientManager.
- Removed unnecessary mocks and fixtures, focusing on essential functionality.
- Introduced new test suite for RAG MCP tool module, covering answer generation and metrics retrieval.
- Added utility functions for registering dependency stubs to streamline test setup.
- Ensured proper cleanup and state management in tests.

## Summary by Sourcery

Add centralized RAG generator caching to ClientManager, refactor ClientManager tests to use shared stub factories, and migrate RAG MCP tools to use the cached generator with new helper functions and unit tests.

New Features:
- Add get_rag_generator method to ClientManager that initializes, caches and locks a shared RAGGenerator instance
- Refactor RAG MCP tools to use client_manager.get_rag_generator and extracted helper functions for enablement checks and request/response mapping

Enhancements:
- Streamline ClientManager unit tests by removing redundant mocks and fixtures and centralizing stub registration in stub_factories
- Modularize RAG tool implementation by extracting request/response builders and enablement validation into separate functions

Documentation:
- Update architecture docs to document RAG generator caching in ClientManager

Tests:
- Introduce stub_factories module to register dependency stubs and simplify test setup
- Overhaul ClientManager test suite to targeted, focused tests with cleanup and state management assertions
- Add new unit tests for RAG tools covering answer generation, metrics retrieval, and disabled-mode handling

Chores:
- Update CHANGELOG to note centralized RAG generator management and improved test coverage